### PR TITLE
Update the pattern for passive sentences "bei ..." to have the ... be…

### DIFF
--- a/zh_gsdsimp-ud-dev.conllu
+++ b/zh_gsdsimp-ud-dev.conllu
@@ -262,7 +262,7 @@
 6	神圣	神圣	ADJ	JJ	_	8	amod	_	SpaceAfter=No|Translit=shénshèng|LTranslit=shénshèng
 7	罗马	罗马	PROPN	NNP	_	8	nmod	_	SpaceAfter=No|Translit=luōmǎ|LTranslit=luōmǎ
 8	帝国	帝国	NOUN	NN	_	9	nmod	_	SpaceAfter=No|Translit=dìguó|LTranslit=dìguó
-9	皇帝	皇帝	NOUN	NN	_	12	nsubj	_	SpaceAfter=No|Translit=huángdì|LTranslit=huángdì
+9	皇帝	皇帝	NOUN	NN	_	12	obl:agent	_	SpaceAfter=No|Translit=huángdì|LTranslit=huángdì
 10	查理	查理	PROPN	NNP	_	9	appos	_	SpaceAfter=No|Translit=chálǐ|LTranslit=chálǐ
 11	四世	四世	PROPN	NNP	_	10	flat:name	_	SpaceAfter=No|Translit=sìshì|LTranslit=sìshì
 12	升	升	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=shēng|LTranslit=shēng
@@ -1735,7 +1735,7 @@
 11	亦	亦	SCONJ	RB	_	16	mark	_	SpaceAfter=No|Translit=yì|LTranslit=yì
 12	被	被	AUX	BB	Voice=Pass	16	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
 13	投机	投机	VERB	VV	_	14	compound	_	SpaceAfter=No|Translit=tóujī|LTranslit=tóujī
-14	者	者	PART	SFN	_	16	nsubj	_	SpaceAfter=No|Translit=zhě|LTranslit=zhě
+14	者	者	PART	SFN	_	16	obl:agent	_	SpaceAfter=No|Translit=zhě|LTranslit=zhě
 15	所	所	SCONJ	RB	_	16	mark	_	SpaceAfter=No|Translit=suǒ|LTranslit=suǒ
 16	觊觎	觊觎	VERB	VV	_	4	parataxis	_	SpaceAfter=No|Translit=觊觎|LTranslit=觊觎
 17	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
@@ -2429,7 +2429,7 @@
 4	账户	账户	NOUN	NN	_	8	nsubj:pass	_	SpaceAfter=No|Translit=账hù|LTranslit=账hù
 5	最后	最后	NOUN	NN	_	8	nmod:tmod	_	SpaceAfter=No|Translit=zuìhòu|LTranslit=zuìhòu
 6	被	被	AUX	BB	Voice=Pass	8	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
-7	半泽	半泽	PROPN	NNP	_	8	nsubj	_	SpaceAfter=No|Translit=bàn泽|LTranslit=bàn泽
+7	半泽	半泽	PROPN	NNP	_	8	obl:agent	_	SpaceAfter=No|Translit=bàn泽|LTranslit=bàn泽
 8	查获	查获	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=cháhuò|LTranslit=cháhuò
 9	，	，	PUNCT	,	_	12	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 10	资产	资产	NOUN	NN	_	12	nsubj	_	SpaceAfter=No|Translit=zīchǎn|LTranslit=zīchǎn
@@ -4568,7 +4568,7 @@
 23	统治	统治	NOUN	NN	_	27	nsubj:pass	_	SpaceAfter=No|Translit=tǒngzhì|LTranslit=tǒngzhì
 24	被	被	AUX	BB	Voice=Pass	27	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
 25	帖木儿	帖木儿	PROPN	NNP	_	26	nmod	_	SpaceAfter=No|Translit=帖mùr|LTranslit=帖mùr
-26	帝国	帝国	NOUN	NN	_	27	nsubj	_	SpaceAfter=No|Translit=dìguó|LTranslit=dìguó
+26	帝国	帝国	NOUN	NN	_	27	obl:agent	_	SpaceAfter=No|Translit=dìguó|LTranslit=dìguó
 27	中断	中断	VERB	VV	_	5	parataxis	_	SpaceAfter=No|Translit=zhōngduàn|LTranslit=zhōngduàn
 28	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
@@ -6097,7 +6097,7 @@
 15	法国	法国	PROPN	NNP	_	18	nmod	_	SpaceAfter=No|Translit=fǎguó|LTranslit=fǎguó
 16	意大利	意大利	PROPN	NNP	_	18	nmod	_	SpaceAfter=No|Translit=yìdàlì|LTranslit=yìdàlì
 17	方面	方面	NOUN	NN	_	18	compound	_	SpaceAfter=No|Translit=fāngmiàn|LTranslit=fāngmiàn
-18	军	军	PART	SFN	_	19	nsubj	_	SpaceAfter=No|Translit=jūn|LTranslit=jūn
+18	军	军	PART	SFN	_	19	obl:agent	_	SpaceAfter=No|Translit=jūn|LTranslit=jūn
 19	打败	打败	VERB	VV	_	27	advcl	_	SpaceAfter=No|Translit=dǎbài|LTranslit=dǎbài
 20	，	，	PUNCT	,	_	19	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 21	最后	最后	NOUN	NN	_	27	nmod:tmod	_	SpaceAfter=No|Translit=zuìhòu|LTranslit=zuìhòu
@@ -7168,7 +7168,7 @@
 23	前	前	ADP	IN	_	22	case	_	SpaceAfter=No|Translit=qián|LTranslit=qián
 24	已	已	ADV	RB	_	31	advmod	_	SpaceAfter=No|Translit=yǐ|LTranslit=yǐ
 25	被	被	AUX	BB	Voice=Pass	31	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
-26	苏格拉底	苏格拉底	PROPN	NNP	_	31	nsubj	_	SpaceAfter=No|Translit=sūgélādǐ|LTranslit=sūgélādǐ
+26	苏格拉底	苏格拉底	PROPN	NNP	_	31	obl:agent	_	SpaceAfter=No|Translit=sūgélādǐ|LTranslit=sūgélādǐ
 27	和	和	CCONJ	CC	_	30	cc	_	SpaceAfter=No|Translit=hé|LTranslit=hé
 28	他	他	PRON	PRP	Person=3	30	det	_	SpaceAfter=No|Translit=tā|LTranslit=tā
 29	的	的	PART	DEC	Case=Gen	28	case	_	SpaceAfter=No|Translit=de|LTranslit=de

--- a/zh_gsdsimp-ud-test.conllu
+++ b/zh_gsdsimp-ud-test.conllu
@@ -697,7 +697,7 @@
 9	教堂	教堂	NOUN	NN	_	13	nsubj:pass	_	SpaceAfter=No|Translit=jiàotáng|LTranslit=jiàotáng
 10	被	被	AUX	BB	Voice=Pass	13	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
 11	马来西亚	马来西亚	PROPN	NNP	_	12	nmod	_	SpaceAfter=No|Translit=mǎláixiyà|LTranslit=mǎláixiyà
-12	政府	政府	NOUN	NN	_	13	nsubj	_	SpaceAfter=No|Translit=zhèngfǔ|LTranslit=zhèngfǔ
+12	政府	政府	NOUN	NN	_	13	obl:agent	_	SpaceAfter=No|Translit=zhèngfǔ|LTranslit=zhèngfǔ
 13	列	列	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=liè|LTranslit=liè
 14	为	为	VERB	VC	_	13	mark	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
 15	50	50	NUM	CD	NumType=Card	19	nummod	_	SpaceAfter=No|Translit=50|LTranslit=50
@@ -3328,7 +3328,7 @@
 45	强大	强大	ADJ	JJ	_	48	amod	_	SpaceAfter=No|Translit=qiángdà|LTranslit=qiángdà
 46	的	的	SCONJ	DEC	_	45	mark:rel	_	SpaceAfter=No|Translit=de|LTranslit=de
 47	流动	流动	NOUN	NN	_	48	nmod	_	SpaceAfter=No|Translit=liúdòng|LTranslit=liúdòng
-48	沙丘	沙丘	NOUN	NN	_	50	nsubj	_	SpaceAfter=No|Translit=shāqiū|LTranslit=shāqiū
+48	沙丘	沙丘	NOUN	NN	_	50	obl:agent	_	SpaceAfter=No|Translit=shāqiū|LTranslit=shāqiū
 49	所	所	SCONJ	RB	_	50	mark	_	SpaceAfter=No|Translit=suǒ|LTranslit=suǒ
 50	淹没	淹没	VERB	VV	_	52	csubj	_	SpaceAfter=No|Translit=yānméi|LTranslit=yānméi
 51	，	，	PUNCT	,	_	50	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
@@ -4837,7 +4837,7 @@
 9	老三	老三	PROPN	NNP	_	8	flat:name	_	SpaceAfter=No|Translit=lǎosān|LTranslit=lǎosān
 10	，	，	PUNCT	,	_	7	punct	_	SpaceAfter=No|Translit=,|LTranslit=,
 11	被	被	AUX	BB	Voice=Pass	15	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
-12	知县	知县	NOUN	NN	_	15	nsubj	_	SpaceAfter=No|Translit=zhīxiàn|LTranslit=zhīxiàn
+12	知县	知县	NOUN	NN	_	15	obl:agent	_	SpaceAfter=No|Translit=zhīxiàn|LTranslit=zhīxiàn
 13	萧	萧	PROPN	NNP	_	12	appos	_	SpaceAfter=No|Translit=萧|LTranslit=萧
 14	汝章	汝章	PROPN	NNP	_	13	flat:name	_	SpaceAfter=No|Translit=汝zhāng|LTranslit=汝zhāng
 15	利用	利用	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=lìyòng|LTranslit=lìyòng
@@ -5261,7 +5261,7 @@
 7	广东	广东	PROPN	NNP	_	8	compound	_	SpaceAfter=No|Translit=guǎngdōng|LTranslit=guǎngdōng
 8	省	省	PART	SFN	_	10	nmod	_	SpaceAfter=No|Translit=shěng|LTranslit=shěng
 9	文化	文化	NOUN	NN	_	10	compound	_	SpaceAfter=No|Translit=wénhuà|LTranslit=wénhuà
-10	厅	厅	PART	SFN	_	11	nsubj	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
+10	厅	厅	PART	SFN	_	11	obl:agent	_	SpaceAfter=No|Translit=tīng|LTranslit=tīng
 11	授予	授予	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=shòuyǔ|LTranslit=shòuyǔ
 12	广东	广东	PROPN	NNP	_	13	compound	_	SpaceAfter=No|Translit=guǎngdōng|LTranslit=guǎngdōng
 13	省	省	PART	SFN	_	18	nmod	_	SpaceAfter=No|Translit=shěng|LTranslit=shěng
@@ -9289,7 +9289,7 @@
 51	又	又	SCONJ	RB	_	56	mark	_	SpaceAfter=No|Translit=yòu|LTranslit=yòu
 52	会	会	AUX	MD	_	56	aux	_	SpaceAfter=No|Translit=huì|LTranslit=huì
 53	被	被	AUX	BB	Voice=Pass	56	aux:pass	_	SpaceAfter=No|Translit=bèi|LTranslit=bèi
-54	方	方	PROPN	NNP	_	56	nsubj	_	SpaceAfter=No|Translit=fāng|LTranslit=fāng
+54	方	方	PROPN	NNP	_	56	obl:agent	_	SpaceAfter=No|Translit=fāng|LTranslit=fāng
 55	芳芳	芳芳	PROPN	NNP	_	54	flat:name	_	SpaceAfter=No|Translit=芳芳|LTranslit=芳芳
 56	打	打	VERB	VV	_	16	parataxis	_	SpaceAfter=No|Translit=dǎ|LTranslit=dǎ
 57	一	一	NUM	CD	NumType=Card	58	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī


### PR DESCRIPTION
Update the pattern for passive sentences "bei ..." to have the ... be the obl:agent instead of a second nsubj

This catches many of the double nsubj sentences currently alarmed by the validator by replacing the second "nsubj" with a relation more appropriate for a passive construction

Semgrex / Ssurgeon update:

```
{}=pass </nsubj:pass/ {}=verb .. ({word:被}=bei < {}=verb .. ({}=agent <nsubj=edge {}=verb))
RelabelNamedEdge -edge edge -reln obl:agent
```

@jemoka

PS. if merged elsewise, would be nice to keep a record of the semgrex & ssurgeon expressions used to make the update.