### PR TITLE
Parallel data representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This is a simplified Chinese version of the UD Chinese GSD treebank. It is initi
 
 # Changelog
 
+* 2025-09-12 v2.16
+  * add parallel corpus information to machine-readable metadata
+  * add parallel data support with parallel_id metadata
 * 2025-11-15 v2.17
   * Fixed attachment clf+det according to the guidelines.
 * 2023-11-15 v2.13
@@ -51,7 +54,7 @@ This is a simplified Chinese version of the UD Chinese GSD treebank. It is initi
 Data available since: UD v2.5
 License: CC BY-SA 4.0
 Includes text: yes
-Parallel: no
+Parallel: zhgsd
 Genre: wiki
 Lemmas: automatic with corrections
 UPOS: converted with corrections

--- a/zh_gsdsimp-ud-dev.conllu
+++ b/zh_gsdsimp-ud-dev.conllu
@@ -1,4 +1,5 @@
 # sent_id = dev-s1
+# parallel_id = zhgsd/dev1
 # text = 同样，施力的大小不同，引起的加速度不同，最终的结果也不一样，亦可以从向量的加成性来看。
 # translit = tóngyàng,shīlìdedàxiǎobùtóng,yǐnqǐdejiāsùdùbùtóng,zuìzhōngdejiéguǒyěbùyīyàng,yìkěyǐcóngxiàngliàngdejiāchéngxìngláikàn.
 1	同样	同样	ADV	RB	_	12	advmod	_	SpaceAfter=No|Translit=tóngyàng|LTranslit=tóngyàng
@@ -33,6 +34,7 @@
 30	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s2
+# parallel_id = zhgsd/dev2
 # text = 大多数的加长型礼车则是租车公司的财产。
 # translit = dàduōshùdejiāzhǎngxínglǐchēzéshìzūchēgōngsīdecáichǎn.
 1	大	大	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=dà|LTranslit=dà
@@ -49,6 +51,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s3
+# parallel_id = zhgsd/dev3
 # text = 这种车辆如果归私人拥有，多半会设置昂贵的音频设备、电视机、影碟机，以及吧台和冰箱。
 # translit = zhèzhǒngchēliàngrúguǒguīsīrényōngyǒu,duōbànhuìshèzhì'ángguìdeyīnpínshèbèi,diànshìjī,yǐngdiéjī,yǐjíbatáihébīngxiāng.
 1	这种	这种	DET	DT	_	2	det	_	SpaceAfter=No|Translit=zhèzhǒng|LTranslit=zhèzhǒng
@@ -79,6 +82,7 @@
 26	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s4
+# parallel_id = zhgsd/dev4
 # text = 动作冒险游戏（A-AVG）：是冒险游戏的分支，它融合了动作游戏的一些特征。
 # translit = dòngzuòmàoxiǎnyóuxì(A-AVG):shìmàoxiǎnyóuxìdefēnzhī,tārónghéledòngzuòyóuxìdeyīxiētèzhēng.
 1	动作	动作	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=dòngzuò|LTranslit=dòngzuò
@@ -105,6 +109,7 @@
 22	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s5
+# parallel_id = zhgsd/dev5
 # text = 其测试包含了美术治疗法，认知行为治疗和洞察疗法，同时给行为分析提供了一个理论性的交流平台。
 # translit = qícèshìbāohánleměishùzhìliáofǎ,rènzhīxíngwèizhìliáohédòngcháliáofǎ,tóngshígěixíngwèifēnxītígōngleyīgèlǐlùnxìngdejiāoliúpíngtái.
 1	其	其	PRON	PRP	Person=3	2	nmod	_	SpaceAfter=No|Translit=qí|LTranslit=qí
@@ -138,6 +143,7 @@
 29	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s6
+# parallel_id = zhgsd/dev6
 # text = 数百万的巧克力棒被撤下柜台，而玛氏则中断了生产，公司损失达四百五十万美元。
 # translit = shùbǎiwàndeqiǎokèlìbàngbèichèxiàguìtái,'érmǎshìzézhōngduànleshēngchǎn,gōngsīsǔnshīdásìbǎiwǔshíwànměiyuán.
 1	数百万	数百万	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=shùbǎiwàn|LTranslit=shùbǎiwàn
@@ -164,6 +170,7 @@
 22	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s7
+# parallel_id = zhgsd/dev7
 # text = 努克的经济以渔业为主，1960年代，鳕鱼业相当发达，现已没落，目前主要出产螃蟹和大比目鱼。
 # translit = nǔkèdejīngjìyǐyúyèwèizhǔ,1960niándài,鳕yúyèxiāngdāngfādá,xiànyǐméiluò,mùqiánzhǔyàochūchǎn螃蟹hédàbǐmùyú.
 1	努克	努克	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=nǔkè|LTranslit=nǔkè
@@ -195,6 +202,7 @@
 27	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s8
+# parallel_id = zhgsd/dev8
 # text = 随后爱斯基摩人和维京人相继定居于此。
 # translit = suíhòu'àisījīmórénhéwéijīngrénxiāngjìdìngjūyúcǐ.
 1	随后	随后	ADV	RB	_	8	advmod	_	SpaceAfter=No|Translit=suíhòu|LTranslit=suíhòu
@@ -210,6 +218,7 @@
 11	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s9
+# parallel_id = zhgsd/dev9
 # text = 五月二十一日，努尔哈赤出城迎接前来沈阳的科尔沁部奥巴贝勒。
 # translit = wǔyuè'èrshíyīrì,nǔ'ěrhāchìchūchéngyíngjiēqiánlái沈yángdekē'ěr沁bù'àobabèilēi.
 1	五	五	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=wǔ|LTranslit=wǔ
@@ -230,6 +239,7 @@
 16	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s10
+# parallel_id = zhgsd/dev10
 # text = 他花费了许多时间来比较加拿大地质调查局博物馆中的恐龙化石。
 # translit = tāhuāfèilexǔduōshíjiānláibǐjiàojiānádàdezhìdiàochájúbówùguǎnzhōngdekǒnglónghuàshí.
 1	他	他	PRON	PRP	Person=3	7	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -252,6 +262,7 @@
 18	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s11
+# parallel_id = zhgsd/dev11
 # text = 1355年，勃兰登堡被神圣罗马帝国皇帝查理四世升为选侯国。
 # translit = 1355nián,bólándēngbǎobèishénshèngluōmǎdìguóhuángdìchálǐsìshìshēngwèixuǎn侯guó.
 1	1355	1355	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1355|LTranslit=1355
@@ -272,6 +283,7 @@
 16	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s12
+# parallel_id = zhgsd/dev12
 # text = 但是迪士尼的公主们不会都太局限于一个范围之内了吗？
 # translit = dànshìdíshìnídegōngzhǔmenbùhuìdōutàijúxiànyúyīgèfànwéizhīnèilema?
 1	但是	但是	SCONJ	RB	_	9	mark	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -293,6 +305,7 @@
 17	？	？	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=?|LTranslit=?
 
 # sent_id = dev-s13
+# parallel_id = zhgsd/dev13
 # text = 华特迪士尼首次邀请数名香港人气博客，参与动画《勇敢传说之幻险森林》配音工作，让他们与其他明星及专业配音员齐齐声演动画。
 # translit = huátèdíshìníshǒucìyāoqǐngshùmíngxiānggǎngrénqìbókè,cānyǔdònghuà«yǒnggǎnchuánshuōzhīhuànxiǎnsēnlín»pèiyīngōngzuò,ràngtāmenyǔqítāmíngxīngjízhuānyèpèiyīnyuánqíqíshēngyǎndònghuà.
 1	华特	华特	PROPN	NNP	_	23	nsubj	_	SpaceAfter=No|Translit=huátè|LTranslit=huátè
@@ -332,6 +345,7 @@
 35	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s14
+# parallel_id = zhgsd/dev14
 # text = 1594年秋，在与特兰西瓦尼亚和摩尔达维亚签订盟约之后，米哈伊起兵反抗奥斯曼帝国，参加神圣罗马帝国发起的十三年战争。
 # translit = 1594niánqiū,zàiyǔtèlánxiwǎníyàhémó'ěrdáwéiyàqiāndìngméngyuēzhīhòu,mǐhāyīqǐbīngfǎnkàng'àosīmàndìguó,cānjiāshénshèngluōmǎdìguófāqǐdeshísānniánzhànzhēng.
 1	1594	1594	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=1594|LTranslit=1594
@@ -365,6 +379,7 @@
 29	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s15
+# parallel_id = zhgsd/dev15
 # text = 在平原、塔、洞窟、海或迷宫中移动时，玩家将会和随机遇到的敌人作战。
 # translit = zàipíngyuán,tǎ,dòngkū,hǎihuòmígōngzhōngyídòngshí,wánjiājiānghuìhésuíjīyùdàodedírénzuòzhàn.
 1	在	在	VERB	VV	_	12	advcl	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -393,6 +408,7 @@
 24	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s16
+# parallel_id = zhgsd/dev16
 # text = 当《Game Informer》提到游戏在日本的知名度时甚至说“四百万日本人可能错了”。
 # translit = dāng«Game Informer»tídàoyóuxìzàirìběndezhīmíngdùshíshénzhìshuō“sìbǎiwànrìběnrénkěnéngcuòle”.
 1	当	当	ADP	IN	_	6	case	_	SpaceAfter=No|Translit=dāng|LTranslit=dāng
@@ -421,6 +437,7 @@
 24	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s17
+# parallel_id = zhgsd/dev17
 # text = 史莱姆是由鸟山明为《勇者斗恶龙》设计的，并成为了系列官方的吉祥物。
 # translit = shǐ莱mǔshìyóuniǎoshānmíngwèi«yǒngzhědòu'èlóng»shèjìde,bìngchéngwèilexìlièguānfāngdejíxiángwù.
 1	史莱姆	史莱姆	PROPN	NNP	_	16	nsubj	_	SpaceAfter=No|Translit=shǐ莱mǔ|LTranslit=shǐ莱mǔ
@@ -449,6 +466,7 @@
 24	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s18
+# parallel_id = zhgsd/dev18
 # text = 日本FC平台的前两作通过密码记忆系统记录进度。
 # translit = rìběnFCpíngtáideqiánliǎngzuòtōngguòmìmǎjìyìxìtǒngjìlùjìndù.
 1	日本	日本	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=rìběn|LTranslit=rìběn
@@ -467,6 +485,7 @@
 14	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s19
+# parallel_id = zhgsd/dev19
 # text = 由于这次失事原因涉及很多敏感的争议性，因此最后仍未有一个具体及统一的事故调查报告。
 # translit = yóuyúzhècìshīshìyuányīnshèjíhěnduōmǐngǎndezhēngyìxìng,yīncǐzuìhòuréngwèiyǒuyīgèjùtǐjítǒngyīdeshìgùdiàochábàogào.
 1	由于	由于	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -498,6 +517,7 @@
 27	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s20
+# parallel_id = zhgsd/dev20
 # text = 年复一年，无论刮风下雨，不顾警察和暴徒骚扰，白衣女士们坚持着她们无声的周日步行，抗议关押古巴的所有良心犯。
 # translit = niánfùyīnián,wúlùnguāfēngxiàyǔ,bùgùjǐngcháhébàotú骚rǎo,báiyīnǚshìmenjiānchízhetāmenwúshēngdezhōurìbùxíng,kàngyìguānyāgǔbadesuǒyǒuliángxīnfàn.
 1	年	年	NOUN	NNB	_	4	obl	_	SpaceAfter=No|Translit=nián|LTranslit=nián
@@ -536,6 +556,7 @@
 34	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s21
+# parallel_id = zhgsd/dev21
 # text = 一个家庭收入的中间数为$16,250，家庭收入的中间数为$16,250，国民平均收入为$5,467。
 # translit = yīgèjiātíngshōurùdezhōngjiānshùwèi$16,250,jiātíngshōurùdezhōngjiānshùwèi$16,250,guómínpíngjūnshōurùwèi$5,467.
 1	一	一	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -567,6 +588,7 @@
 27	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s22
+# parallel_id = zhgsd/dev22
 # text = 劳特塔瓦尔湖是印度尼西亚的湖泊，位于苏门答腊岛北部，由亚齐特别行政区负责管辖，长17公里、宽3公里，面积70平方公里，海拔高度1,100米，最大水深80米，蓄水量25亿立方米。
 # translit = láotètǎwǎ'ěrhúshìyìndùníxiyàdehúpō,wèiyúsūméndá腊dǎoběibù,yóuyàqítèbiéxíngzhèngqūfùzéguǎnxiá,zhǎng17gōnglǐ,kuān3gōnglǐ,miànjī70píngfānggōnglǐ,hǎibágāodù1,100mǐ,zuìdàshuǐshēn80mǐ,xùshuǐliàng25yìlìfāngmǐ.
 1	劳特塔瓦尔	劳特塔瓦尔	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=láotètǎwǎ'ěr|LTranslit=láotètǎwǎ'ěr
@@ -619,6 +641,7 @@
 48	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s23
+# parallel_id = zhgsd/dev23
 # text = 总面积24.44平方公里，人口3108人，人口密度127.2人/平方公里（2009年）。
 # translit = zǒngmiànjī24.44píngfānggōnglǐ,rénkǒu3108rén,rénkǒumìdù127.2rén/píngfānggōnglǐ(2009nián).
 1	总	总	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=zǒng|LTranslit=zǒng
@@ -643,6 +666,7 @@
 20	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s24
+# parallel_id = zhgsd/dev24
 # text = 包白铁路全线共设有车站19座。
 # translit = bāobáitiělùquánxiàngòngshèyǒuchēzhàn19zuò.
 1	包	包	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=bāo|LTranslit=bāo
@@ -657,6 +681,7 @@
 10	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s25
+# parallel_id = zhgsd/dev25
 # text = 包盈盈所在的第三区，有卫冕冠军、6号种子玛丽埃尔·扎格尼斯。
 # translit = bāo盈盈suǒzàidedìsānqū,yǒuwèi冕guānjūn,6hàozhǒngzimǎlì'āi'ěr·zhāgénísī.
 1	包	包	PROPN	NNP	_	4	nsubj	_	SpaceAfter=No|Translit=bāo|LTranslit=bāo
@@ -680,6 +705,7 @@
 19	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s26
+# parallel_id = zhgsd/dev26
 # text = 由于包浩斯学校对于现代建筑学的深远影响，今日的包浩斯早已不单是指学校，而是其倡导的建筑流派或风格的统称，注重建筑造型与实用机能合而为一。
 # translit = yóuyúbāohàosīxuéxiàoduìyúxiàndàijiànzhùxuédeshēnyuǎnyǐngxiǎng,jīnrìdebāohàosīzǎoyǐbùdānshìzhǐxuéxiào,'érshìqíchàngdǎodejiànzhùliúpàihuòfēnggédetǒngchēng,zhùzhòngjiànzhùzàoxíngyǔshíyòngjīnénghé'érwèiyī.
 1	由于	由于	ADP	IN	_	10	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -724,6 +750,7 @@
 40	。	。	PUNCT	.	_	33	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s27
+# parallel_id = zhgsd/dev27
 # text = 1956年，首次推行的许多改革措施在卡达尔当政期间虽依然保留，但在外交上却没有任何大的改变。
 # translit = 1956nián,shǒucìtuīxíngdexǔduōgǎigécuòshīzàikǎdá'ěrdāngzhèngqījiānsuīyīránbǎoliú,dànzàiwàijiāoshàngquèméiyǒurènhédàdegǎibiàn.
 1	1956	1956	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1956|LTranslit=1956
@@ -756,6 +783,7 @@
 28	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s28
+# parallel_id = zhgsd/dev28
 # text = 化外之地，文明地区以外的地方，即没有开化的地方。
 # translit = huàwàizhīde,wénmíngdeqūyǐwàidedefāng,jíméiyǒukāihuàdedefāng.
 1	化外	化外	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=huàwài|LTranslit=huàwài
@@ -776,6 +804,7 @@
 16	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s29
+# parallel_id = zhgsd/dev29
 # text = 地下一层南北两侧设有公交站，地下二层为地铁4号线，地下三层为正在建设的地铁14号线。
 # translit = dexiàyīcéngnánběiliǎngcèshèyǒugōngjiāozhàn,dexià'èrcéngwèidetiě4hàoxiàn,dexiàsāncéngwèizhèngzàijiànshèdedetiě14hàoxiàn.
 1	地下	地下	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=dexià|LTranslit=dexià
@@ -812,6 +841,7 @@
 32	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s30
+# parallel_id = zhgsd/dev30
 # text = 它的前身是1901年的永定门站，到1957年至1958年扩建为辅助客运站，2006年至2008年拆除重建。
 # translit = tādeqiánshēnshì1901niándeyǒngdìngménzhàn,dào1957niánzhì1958niánkuòjiànwèifǔzhùkèyùnzhàn,2006niánzhì2008niánchāichúzhòngjiàn.
 1	它	它	PRON	PRP	Person=3	3	det	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -847,6 +877,7 @@
 31	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s31
+# parallel_id = zhgsd/dev31
 # text = 当时国安二队的年轻球员普遍达不到一队的水平，以至于联赛开始时国安一线队的注册队员只有十八名。
 # translit = dāngshíguó'ān'èrduìdeniánqīngqiúyuánpǔbiàndábùdàoyīduìdeshuǐpíng,yǐzhìyúliánsàikāishǐshíguó'ānyīxiànduìdezhùcèduìyuánzhǐyǒushíbāmíng.
 1	当时	当时	NOUN	NN	_	9	nmod:tmod	_	SpaceAfter=No|Translit=dāngshí|LTranslit=dāngshí
@@ -883,6 +914,7 @@
 32	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s32
+# parallel_id = zhgsd/dev32
 # text = 更新日期：2013年8月26日本赛季，北京国安再次提前一轮锁定联赛季军，由于亚足联确认中超联赛获得3.5个亚冠联赛小组赛的直接参赛席位，故国安队获得了下赛季亚冠联赛的席位，但需等到中国足协杯赛事结束后方可确定是否能够直接晋级小组赛。
 # translit = gèngxīnrìqī:2013nián8yuè26rìběnsàijì,běijīngguó'ānzàicìtíqiányīlúnsuǒdìngliánsàijìjūn,yóuyúyàzúliánquèrènzhōngchāoliánsàihuòde3.5gèyàguānliánsàixiǎozǔsàidezhíjiēcānsàixíwèi,gùguó'ānduìhuòdelexiàsàijìyàguānliánsàidexíwèi,dànxūděngdàozhōngguózúxiébēisàishìjiéshùhòufāngkěquèdìngshìfǒunénggòuzhíjiē晋jíxiǎozǔsài.
 1	更新	更新	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=gèngxīn|LTranslit=gèngxīn
@@ -957,6 +989,7 @@
 70	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s33
+# parallel_id = zhgsd/dev33
 # text = 2008年，该工程并未完工。
 # translit = 2008nián,gāigōngchéngbìngwèiwángōng.
 1	2008	2008	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2008|LTranslit=2008
@@ -970,6 +1003,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s34
+# parallel_id = zhgsd/dev34
 # text = 北京外城共有七门，南面三门，东西各一门，此外还有两座便门。
 # translit = běijīngwàichénggòngyǒuqīmén,nánmiànsānmén,dōngxigèyīmén,cǐwàiháiyǒuliǎngzuòbiànmén.
 1	北京	北京	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=běijīng|LTranslit=běijīng
@@ -997,6 +1031,7 @@
 23	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s35
+# parallel_id = zhgsd/dev35
 # text = 瓮城为元朝末年所修，因为当时崇仁门为东垣正中城门，因此瓮城几乎为正方形，南北宽68米，东西深62米，南面辟闸楼、券门。
 # translit = 瓮chéngwèiyuáncháomòniánsuǒxiū,yīnwèidāngshíchóngrénménwèidōng垣zhèngzhōngchéngmén,yīncǐ瓮chéngjǐhuwèizhèngfāngxíng,nánběikuān68mǐ,dōngxishēn62mǐ,nánmiànpìzhálóu,券mén.
 1	瓮城	瓮城	PROPN	NNP	_	6	nsubj:pass	_	SpaceAfter=No|Translit=瓮chéng|LTranslit=瓮chéng
@@ -1041,6 +1076,7 @@
 40	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s36
+# parallel_id = zhgsd/dev36
 # text = 该部位于北京大学医学部逸夫楼7楼。
 # translit = gāibùwèiyúběijīngdàxuéyīxuébù逸fulóu7lóu.
 1	该部	该部	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=gāibù|LTranslit=gāibù
@@ -1057,6 +1093,7 @@
 12	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s37
+# parallel_id = zhgsd/dev37
 # text = 2010年1月7日，北京市教育委员会正式作出批复，要求该校停止体制改革试点，加入公立校行列。
 # translit = 2010nián1yuè7rì,běijīngshìjiàoyùwěiyuánhuìzhèngshìzuòchūpīfù,yàoqiúgāixiàotíngzhǐtǐzhìgǎigéshìdiǎn,jiārùgōnglìxiàoxíngliè.
 1	2010	2010	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2010|LTranslit=2010
@@ -1090,6 +1127,7 @@
 29	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s38
+# parallel_id = zhgsd/dev38
 # text = 而且学校的伙食和住宿条件也多年遭到在校生的诟病。
 # translit = 'érqiěxuéxiàodehuǒshíhézhùsùtiáojiànyěduōniánzāodàozàixiàoshēngde诟bìng.
 1	而且	而且	SCONJ	RB	_	11	mark	_	SpaceAfter=No|Translit='érqiě|LTranslit='érqiě
@@ -1110,6 +1148,7 @@
 16	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s39
+# parallel_id = zhgsd/dev39
 # text = 支线从朝阳门到杨闸环岛后继续向东行驶，上京哈高速后到达通州武夷花园小区。
 # translit = zhīxiàncóngcháoyángméndàoyángzháhuándǎohòujìxùxiàngdōngxíngshǐ,shàngjīnghāgāosùhòudàodátōngzhōuwǔ夷huāyuánxiǎoqū.
 1	支线	支线	NOUN	NN	_	19	nsubj	_	SpaceAfter=No|Translit=zhīxiàn|LTranslit=zhīxiàn
@@ -1138,6 +1177,7 @@
 24	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s40
+# parallel_id = zhgsd/dev40
 # text = 车站装有屏蔽门，采用与轨道交通类似的管理方法，但2号线并没有全线的专用路权。
 # translit = chēzhànzhuāngyǒupíngbìmén,cǎiyòngyǔguǐdàojiāotōnglèishìdeguǎnlǐfāngfǎ,dàn2hàoxiànbìngméiyǒuquánxiàndezhuānyònglùquán.
 1	车站	车站	NOUN	NN	_	6	nsubj	_	SpaceAfter=No|Translit=chēzhàn|LTranslit=chēzhàn
@@ -1167,6 +1207,7 @@
 25	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s41
+# parallel_id = zhgsd/dev41
 # text = 1978年，学院恢复了本科生招生，该届学生在1982年成为北京电影学院首批被授予学士学位的毕业生，在这以后的三十多年所培养的各个专业的众多学生，成为了中国乃至世界著名的电影人，为中国电影在全世界的影响做出了重要的贡献。
 # translit = 1978nián,xuéyuànhuīfùleběnkēshēngzhāoshēng,gāijièxuéshēngzài1982niánchéngwèiběijīngdiànyǐngxuéyuànshǒupībèishòuyǔxuéshìxuéwèidebìyèshēng,zàizhèyǐhòudesānshíduōniánsuǒpéiyǎngdegègèzhuānyèdezhòngduōxuéshēng,chéngwèilezhōngguónǎizhìshìjièzhemíngdediànyǐngrén,wèizhōngguódiànyǐngzàiquánshìjièdeyǐngxiǎngzuòchūlezhòngyàodegòngxiàn.
 1	1978	1978	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1978|LTranslit=1978
@@ -1240,6 +1281,7 @@
 69	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s42
+# parallel_id = zhgsd/dev42
 # text = 2009年报考人数达1.3万余人次，计划招生只有440人，淘汰率超过96%。
 # translit = 2009niánbàokǎorénshùdá1.3wànyúréncì,jìhuàzhāoshēngzhǐyǒu440rén,táotàilǜchāoguò96%.
 1	2009	2009	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2009|LTranslit=2009
@@ -1263,6 +1305,7 @@
 19	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s43
+# parallel_id = zhgsd/dev43
 # text = 北京站是当时中国大陆规模最大、设备最先进的铁路车站，也是第一个现代化大型铁路客运站。
 # translit = běijīngzhànshìdāngshízhōngguódàlùguīmózuìdà,shèbèizuìxiānjìndetiělùchēzhàn,yěshìdìyīgèxiàndàihuàdàxíngtiělùkèyùnzhàn.
 1	北京	北京	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=běijīng|LTranslit=běijīng
@@ -1293,6 +1336,7 @@
 26	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s44
+# parallel_id = zhgsd/dev44
 # text = 为了改善中央空档的视觉效果，故借鉴中国传统城门楼的设计，设计成一个宽45米、高50米的“门洞”。
 # translit = wèilegǎishànzhōngyāngkōngdàngdeshìjuéxiàoguǒ,gùjièjiànzhōngguóchuántǒngchéngménlóudeshèjì,shèjìchéngyīgèkuān45mǐ,gāo50mǐde“méndòng”.
 1	为了	为了	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=wèile|LTranslit=wèile
@@ -1330,6 +1374,7 @@
 33	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s45
+# parallel_id = zhgsd/dev45
 # text = 他每天赶着马车到灾区逐村收养灾童，总人数近800名。
 # translit = tāměitiāngǎnzhemǎchēdàozāiqūzhúcūnshōuyǎngzāitóng,zǒngrénshùjìn800míng.
 1	他	他	PRON	PRP	Person=3	9	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -1351,6 +1396,7 @@
 17	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s46
+# parallel_id = zhgsd/dev46
 # text = 在北印度洋产生的气旋风暴是由印度气象部新德里台风中心命名，而在该地区的热带低气压的编号都以A/B字母作结。
 # translit = zàiběiyìndùyángchǎnshēngdeqìxuánfēngbàoshìyóuyìndùqìxiàngbùxīndélǐtáifēngzhōngxīnmìngmíng,'érzàigāideqūderèdàidīqìyādebiānhàodōuyǐA/Bzìmǔzuòjié.
 1	在	在	VERB	VV	_	5	advcl	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -1392,6 +1438,7 @@
 37	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s47
+# parallel_id = zhgsd/dev47
 # text = 此气旋季之风暴通常都会于4月至12月期间形成。
 # translit = cǐqìxuánjìzhīfēngbàotōngchángdōuhuìyú4yuèzhì12yuèqījiānxíngchéng.
 1	此	此	DET	DT	_	3	det	_	SpaceAfter=No|Translit=cǐ|LTranslit=cǐ
@@ -1413,6 +1460,7 @@
 17	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s48
+# parallel_id = zhgsd/dev48
 # text = 天帝军得知真相后，也为法鲁克与拳四郎的对决划下休止符。
 # translit = tiāndìjūndezhīzhēnxiānghòu,yěwèifǎlǔkèyǔquánsì郎deduìjuéhuàxiàxiūzhǐfú.
 1	天帝	天帝	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=tiāndì|LTranslit=tiāndì
@@ -1434,6 +1482,7 @@
 17	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s49
+# parallel_id = zhgsd/dev49
 # text = 而解药的出现也使得他们在公众中得到了威望，并将北方之火推上权力宝座。
 # translit = 'érjiěyàodechūxiànyěshǐdetāmenzàigōngzhòngzhōngdedàolewēiwàng,bìngjiāngběifāngzhīhuǒtuīshàngquánlìbǎozuò.
 1	而	而	SCONJ	RB	_	20	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -1461,6 +1510,7 @@
 23	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s50
+# parallel_id = zhgsd/dev50
 # text = 那股充满狂气的演技力，并非只有身为演员的狂气，而是表现于“演技”上的狂气。
 # translit = nàgǔchōngmǎnkuángqìdeyǎnjìlì,bìngfēizhǐyǒushēnwèiyǎnyuándekuángqì,'érshìbiǎoxiànyú“yǎnjì”shàngdekuángqì.
 1	那	那	DET	DT	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -1490,6 +1540,7 @@
 25	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s51
+# parallel_id = zhgsd/dev51
 # text = 北极土著民族一直与外界接触甚少，直到现代，与其他地区的交流才开始变得频繁。
 # translit = běijítǔzhemínzúyīzhíyǔwàijièjiēchùshénshǎo,zhídàoxiàndài,yǔqítādeqūdejiāoliúcáikāishǐbiàndepínfán.
 1	北极	北极	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=běijí|LTranslit=běijí
@@ -1517,6 +1568,7 @@
 23	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s52
+# parallel_id = zhgsd/dev52
 # text = 为了避免此等事故发生，飞机的所有装置，包括发动机、辅助动力装置、电力、液压系统等，都需要更为严格的防护性维修。
 # translit = wèilebìmiǎncǐděngshìgùfāshēng,fēijīdesuǒyǒuzhuāngzhì,bāokuòfādòngjī,fǔzhùdònglìzhuāngzhì,diànlì,yèyāxìtǒngděng,dōuxūyàogèngwèiyángédefánghùxìngwéixiū.
 1	为了	为了	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=wèile|LTranslit=wèile
@@ -1555,6 +1607,7 @@
 34	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s53
+# parallel_id = zhgsd/dev53
 # text = 由于北极地区的盛行西风一般强度较弱，再加上北极航线更接近大圆航线、航程较短，因此，越来越多往西飞（例如从纽约到香港）的航班，都会取道北极航线，节省时间之余，还可以节省燃料，并增加有效负载。
 # translit = yóuyúběijídeqūdeshèngxíngxifēngyībānqiángdùjiàoruò,zàijiāshàngběijíhángxiàngèngjiējìndàyuánhángxiàn,hángchéngjiàoduǎn,yīncǐ,yuèláiyuèduōwǎngxifēi(lìrúcóngniǔyuēdàoxiānggǎng)dehángbān,dōuhuìqǔdàoběijíhángxiàn,jiéshěngshíjiānzhīyú,háikěyǐjiéshěngránliào,bìngzēngjiāyǒuxiàofùzài.
 1	由于	由于	ADP	IN	_	12	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -1619,6 +1672,7 @@
 60	。	。	PUNCT	.	_	57	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s54
+# parallel_id = zhgsd/dev54
 # text = 五岁后，雌性约2.5米长，300公斤，成长速度减慢很多，但雄性可能到五到八岁性发育完全之后才停止成长，到那时长到3.33 m左右，而且胸，颈和上身宽大，重量达到600-1100公斤。
 # translit = wǔsuìhòu,cíxìngyuē2.5mǐzhǎng,300gōngjīn,chéngzhǎngsùdùjiǎnmànhěnduō,dànxióngxìngkěnéngdàowǔdàobāsuìxìngfāyùwánquánzhīhòucáitíngzhǐchéngzhǎng,dàonàshízhǎngdào3.33 mzuǒyòu,'érqiěxiōng,jǐnghéshàngshēnkuāndà,zhòngliàngdádào600-1100gōngjīn.
 1	五	五	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=wǔ|LTranslit=wǔ
@@ -1680,6 +1734,7 @@
 57	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s55
+# parallel_id = zhgsd/dev55
 # text = 位于校园北区的重要文化遗产札幌农学校第二农场，是根据克拉克博士的构想而建立的模范家畜饲育场，多为明治时期的建筑物。
 # translit = wèiyúxiàoyuánběiqūdezhòngyàowénhuàyíchǎn札幌nóngxuéxiàodì'èrnóngchǎng,shìgēnjùkèlākèbóshìdegòuxiǎng'érjiànlìdemófànjiāchùsìyùchǎng,duōwèimíngzhìshíqīdejiànzhùwù.
 1	位	位	VERB	VV	_	8	acl:relcl	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -1720,6 +1775,7 @@
 36	。	。	PUNCT	.	_	35	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s56
+# parallel_id = zhgsd/dev56
 # text = 市内后来也铺设了有轨电车系统，地段亦被投机者所觊觎。
 # translit = shìnèihòuláiyěpùshèleyǒuguǐdiànchēxìtǒng,deduànyìbèitóujīzhěsuǒ觊觎.
 1	市内	市内	NOUN	NN	_	4	nsubj	_	SpaceAfter=No|Translit=shìnèi|LTranslit=shìnèi
@@ -1741,6 +1797,7 @@
 17	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s57
+# parallel_id = zhgsd/dev57
 # text = 天津河北体育场建成后占地面积为20万平方米、建筑面积为4.5万平方米，体育场的看台设有18级台阶，为马蹄形的水泥钢筋建筑。
 # translit = tiānjīnhéběitǐyùchǎngjiànchénghòuzhàndemiànjīwèi20wànpíngfāngmǐ,jiànzhùmiànjīwèi4.5wànpíngfāngmǐ,tǐyùchǎngdekàntáishèyǒu18jítáijiē,wèimǎtíxíngdeshuǐnígāngjīnjiànzhù.
 1	天津	天津	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=tiānjīn|LTranslit=tiānjīn
@@ -1780,6 +1837,7 @@
 35	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s58
+# parallel_id = zhgsd/dev58
 # text = 此后，第18届华北运动会筹备委员会利用天津市政府的26万元拨款和河北省政府的20万元拨款兴建北站体育场，其余款项用于招待运动员和华北运动会工作人员。
 # translit = cǐhòu,dì18jièhuáběiyùndònghuì筹bèiwěiyuánhuìlìyòngtiānjīnshìzhèngfǔde26wànyuánbōkuǎnhéhéběishěngzhèngfǔde20wànyuánbōkuǎnxìngjiànběizhàntǐyùchǎng,qíyúkuǎnxiàngyòngyúzhāodàiyùndòngyuánhéhuáběiyùndònghuìgōngzuòrényuán.
 1	此后	此后	NOUN	NN	_	28	obl	_	SpaceAfter=No|Translit=cǐhòu|LTranslit=cǐhòu
@@ -1831,6 +1889,7 @@
 47	。	。	PUNCT	.	_	28	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s59
+# parallel_id = zhgsd/dev59
 # text = 直至2002年8月，将军澳线全线通车，本站变为港岛线及将军澳线的转车站。
 # translit = zhízhì2002nián8yuè,jiāngjūn'àoxiànquánxiàntōngchē,běnzhànbiànwèigǎngdǎoxiànjíjiāngjūn'àoxiàndezhuǎnchēzhàn.
 1	直至	直至	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=zhízhì|LTranslit=zhízhì
@@ -1860,6 +1919,7 @@
 25	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s60
+# parallel_id = zhgsd/dev60
 # text = 于是李朝政府采取措施：一方面加强朝鲜半岛东北面的防务；一方面对图们江南北女真施加压力，给以绝市的制裁。
 # translit = yúshìlicháozhèngfǔcǎiqǔcuòshī:yīfāngmiànjiāqiángcháoxiānbàndǎodōngběimiàndefángwu;yīfāngmiànduìtúmenjiāngnánběinǚzhēnshījiāyālì,gěiyǐjuéshìdezhìcái.
 1	于是	于是	SCONJ	RB	_	28	mark	_	SpaceAfter=No|Translit=yúshì|LTranslit=yúshì
@@ -1897,6 +1957,7 @@
 33	。	。	PUNCT	.	_	28	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s61
+# parallel_id = zhgsd/dev61
 # text = 北黄土沟站是一个大准线上的铁路车站，位于内蒙古自治区丰镇市新城湾乡北黄土沟，建于1996年，目前为四等站，邮政编码为012105。
 # translit = běihuángtǔgōuzhànshìyīgèdàzhǔnxiànshàngdetiělùchēzhàn,wèiyúnèiménggǔzìzhìqūfēngzhènshìxīnchéngwānxiāngběihuángtǔgōu,jiànyú1996nián,mùqiánwèisìděngzhàn,yóuzhèngbiānmǎwèi012105.
 1	北	北	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=běi|LTranslit=běi
@@ -1946,6 +2007,7 @@
 45	。	。	PUNCT	.	_	39	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s62
+# parallel_id = zhgsd/dev62
 # text = 鉴于此业务模式取得空前成功，双方扩充娱乐场业务至占据新建业商业中心五层空间，集团与澳博的合作亦因而更趋紧密。
 # translit = jiànyúcǐyèwumóshìqǔdekōngqiánchénggōng,shuāngfāngkuòchōngyúlèchǎngyèwuzhìzhànjùxīnjiànyèshāngyèzhōngxīnwǔcéngkōngjiān,jítuányǔ'àobódehézuòyìyīn'érgèngqūjǐnmì.
 1	鉴	鉴	VERB	VV	_	12	advcl	_	SpaceAfter=No|Translit=jiàn|LTranslit=jiàn
@@ -1984,6 +2046,7 @@
 34	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s63
+# parallel_id = zhgsd/dev63
 # text = 只是在纽约州，就有500多所学校将匹克球设为课程。
 # translit = zhǐshìzàiniǔyuēzhōu,jiùyǒu500duōsuǒxuéxiàojiāngpǐkèqiúshèwèikèchéng.
 1	只	只	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=zhǐ|LTranslit=zhǐ
@@ -2006,6 +2069,7 @@
 18	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s64
+# parallel_id = zhgsd/dev64
 # text = 区位论要解决的是经济活动的地理方位及其形成原因的问题。
 # translit = qūwèilùnyàojiějuédeshìjīngjìhuódòngdedelǐfāngwèijíqíxíngchéngyuányīndewèntí.
 1	区位	区位	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=qūwèi|LTranslit=qūwèi
@@ -2028,6 +2092,7 @@
 18	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s65
+# parallel_id = zhgsd/dev65
 # text = 所谓医学生物化学大多是将生物化学中与医学、人体功能较为相关部分整理后所得。
 # translit = suǒwèiyīxuéshēngwùhuàxuédàduōshìjiāngshēngwùhuàxuézhōngyǔyīxué,réntǐgōngnéngjiàowèixiāngguānbùfēnzhěnglǐhòusuǒde.
 1	所	所	SCONJ	RB	_	2	mark	_	SpaceAfter=No|Translit=suǒ|LTranslit=suǒ
@@ -2056,6 +2121,7 @@
 24	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s66
+# parallel_id = zhgsd/dev66
 # text = 消费者通过线下十二篮体重秤称重，将数据传输到十二篮体重资料库云端，通过app、官网等终端为消费者推送个性解决方案，实现全程数字化监测管理，确保方案科学和持续性。
 # translit = xiāofèizhětōngguòxiànxiàshí'èrlántǐzhòngchèngchēngzhòng,jiāngshùjùchuánshūdàoshí'èrlántǐzhòngzīliàokùyúnduān,tōngguòapp,guānwǎngděngzhōngduānwèixiāofèizhětuīsònggèxìngjiějuéfāng'àn,shíxiànquánchéngshùzìhuàjiāncèguǎnlǐ,quèbǎofāng'ànkēxuéhéchíxùxìng.
 1	消费	消费	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=xiāofèi|LTranslit=xiāofèi
@@ -2109,6 +2175,7 @@
 49	。	。	PUNCT	.	_	43	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s67
+# parallel_id = zhgsd/dev67
 # text = 旧街坊改造后，十全街两侧为新建的古典风格建筑，是餐饮业、茶楼酒吧和各式工艺品商店（苏绣、字画古董、紫砂陶器、红木小件）集中的特色街道。
 # translit = jiùjiēfanggǎizàohòu,shíquánjiēliǎngcèwèixīnjiàndegǔdiǎnfēnggéjiànzhù,shìcānyǐnyè,chálóujiǔbahégèshìgōngyìpǐnshāngdiàn(sūxiù,zìhuàgǔ董,zǐshātáoqì,hóngmùxiǎojiàn)jízhōngdetèsèjiēdào.
 1	旧	旧	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
@@ -2157,6 +2224,7 @@
 44	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s68
+# parallel_id = zhgsd/dev68
 # text = 关于十八铜人的具体描述非常分歧。
 # translit = guānyúshíbātóngréndejùtǐmiáoshùfēichángfēn歧.
 1	关于	关于	ADP	IN	_	6	case	_	SpaceAfter=No|Translit=guānyú|LTranslit=guānyú
@@ -2170,6 +2238,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s69
+# parallel_id = zhgsd/dev69
 # text = 当年为培养“天下最恶的人”，说服十大恶人饶过小鱼儿。
 # translit = dāngniánwèipéiyǎng“tiānxiàzuì'èderén”,shuōfúshídà'èrénráoguòxiǎoyúr.
 1	当年	当年	NOUN	NN	_	11	nmod:tmod	_	SpaceAfter=No|Translit=dāngnián|LTranslit=dāngnián
@@ -2191,6 +2260,7 @@
 17	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s70
+# parallel_id = zhgsd/dev70
 # text = 黑骏马》、《绿化树》、《晚霞消失的时候》、《高山下的花环》、《雪城》、《北京人在纽约》等作品都是获得该奖项的文学作品。
 # translit = hēi骏mǎ»,«lǜhuàshù»,«wǎnxiáxiāoshīdeshíhou»,«gāoshānxiàdehuāhuán»,«xuěchéng»,«běijīngrénzàiniǔyuē»děngzuòpǐndōushìhuòdegāijiǎngxiàngdewénxuézuòpǐn.
 1	黑	黑	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=hēi|LTranslit=hēi
@@ -2238,6 +2308,7 @@
 43	。	。	PUNCT	.	_	42	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s71
+# parallel_id = zhgsd/dev71
 # text = 本片制作成本超越上一部，达8000万港币，故事背景也与上集截然不同。
 # translit = běnpiànzhìzuòchéngběnchāoyuèshàngyībù,dá8000wàngǎngbì,gùshìbèijǐngyěyǔshàngjíjiéránbùtóng.
 1	本片	本片	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=běnpiàn|LTranslit=běnpiàn
@@ -2262,6 +2333,7 @@
 20	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s72
+# parallel_id = zhgsd/dev72
 # text = 截至2009年，千禧公园是全芝加哥人气第二高的旅游景点，仅次于海军码头（Navy's Pier）。
 # translit = jiézhì2009nián,qiān禧gōngyuánshìquánzhījiāgērénqìdì'èrgāodelǚyóujǐngdiǎn,jǐncìyúhǎijūnmǎtóu(Navy's Pier).
 1	截	截	VERB	VV	_	19	advcl	_	SpaceAfter=No|Translit=jié|LTranslit=jié
@@ -2293,6 +2365,7 @@
 27	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s73
+# parallel_id = zhgsd/dev73
 # text = 老子在本章中主要是向帝王阐述治国之术，要王者注重时政中细微的变化，遵循事物发展规律，顺应自然，以达“无为”而治之目的。
 # translit = lǎozizàiběnzhāngzhōngzhǔyàoshìxiàngdìwángchǎnshùzhìguózhīshù,yàowángzhězhùzhòngshízhèngzhōngxìwēidebiànhuà,zūnxúnshìwùfāzhǎnguīlǜ,shùnyīngzìrán,yǐdá“wúwèi”'érzhìzhīmùde.
 1	老子	老子	PROPN	NNP	_	32	nsubj	_	SpaceAfter=No|Translit=lǎozi|LTranslit=lǎozi
@@ -2337,6 +2410,7 @@
 40	。	。	PUNCT	.	_	32	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s74
+# parallel_id = zhgsd/dev74
 # text = 升A小调是一个于升A音开始的音乐的小调，组成的音有#A、#B（C）、#C、#D、#E（F）、#F、#G及#A（和声小调）。
 # translit = shēngAxiǎodiàoshìyīgèyúshēngAyīnkāishǐdeyīnlèdexiǎodiào,zǔchéngdeyīnyǒu#A,#B(C),#C,#D,#E(F),#F,#Gjí#A(héshēngxiǎodiào).
 1	升	升	VERB	VV	_	3	amod	_	SpaceAfter=No|Translit=shēng|LTranslit=shēng
@@ -2387,6 +2461,7 @@
 46	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s75
+# parallel_id = zhgsd/dev75
 # text = 半月山大佛又称资阳大佛，位于四川省资阳市雁江区碑记镇，是一座在山崖石壁上雕刻的佛像。
 # translit = bànyuèshāndàfúyòuchēngzīyángdàfú,wèiyúsìchuānshěngzīyángshì雁jiāngqūbēijìzhèn,shìyīzuòzàishānyáshíbìshàngdiāokèdefúxiàng.
 1	半月	半月	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=bànyuè|LTranslit=bànyuè
@@ -2421,6 +2496,7 @@
 30	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s76
+# parallel_id = zhgsd/dev76
 # text = 但其秘密账户最后被半泽查获，资产全遭冻结，身败名裂。
 # translit = dànqímìmì账hùzuìhòubèibàn泽cháhuò,zīchǎnquánzāodòngjié,shēnbàimíngliè.
 1	但	但	SCONJ	RB	_	8	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -2441,6 +2517,7 @@
 16	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s77
+# parallel_id = zhgsd/dev77
 # text = 半腰座椅，亦称半腰位、半截座椅，铁路车辆座位的一种。
 # translit = bànyāozuòyǐ,yìchēngbànyāowèi,bànjiézuòyǐ,tiělùchēliàngzuòwèideyīzhǒng.
 1	半	半	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=bàn|LTranslit=bàn
@@ -2466,6 +2543,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s78
+# parallel_id = zhgsd/dev78
 # text = 在美国人的心目中，华尔街是一个依靠贸易、资本主义和创新，而非殖民主义和掠夺成长的国家和经济系统的象征。
 # translit = zàiměiguóréndexīnmùzhōng,huá'ěrjiēshìyīgèyīkàomàoyì,zīběnzhǔyìhéchuàngxīn,'érfēizhímínzhǔyìhé'èduóchéngzhǎngdeguójiāhéjīngjìxìtǒngdexiàngzhēng.
 1	在	在	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -2504,6 +2582,7 @@
 34	。	。	PUNCT	.	_	33	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s79
+# parallel_id = zhgsd/dev79
 # text = 华尔街的公司反对政府的监督与管制。
 # translit = huá'ěrjiēdegōngsīfǎnduìzhèngfǔdejiāndūyǔguǎnzhì.
 1	华尔	华尔	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=huá'ěr|LTranslit=huá'ěr
@@ -2519,6 +2598,7 @@
 11	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s80
+# parallel_id = zhgsd/dev80
 # text = 华山松（学名：Pinus armandii），是一种松科植物。
 # translit = huáshānsōng(xuémíng:Pinus armandii),shìyīzhǒngsōngkēzhíwù.
 1	华山松	华山松	NOUN	NN	_	13	nsubj	_	SpaceAfter=No|Translit=huáshānsōng|LTranslit=huáshānsōng
@@ -2537,6 +2617,7 @@
 14	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s81
+# parallel_id = zhgsd/dev81
 # text = 8月14日，Radzymin失守，波兰第五军团的战线被突破。
 # translit = 8yuè14rì,Radzyminshīshǒu,bōlándìwǔjūntuándezhànxiànbèitūpò.
 1	8	8	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=8|LTranslit=8
@@ -2557,6 +2638,7 @@
 16	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s82
+# parallel_id = zhgsd/dev82
 # text = 他手上有24师的兵力，意图仿效俄军将领Ivan Paskievich在1831年的“十一月起义”中采用的方法去占领华沙。
 # translit = tāshǒushàngyǒu24shīdebīnglì,yìtúfǎngxiào'éjūnjiānglǐngIvan Paskievichzài1831niánde“shíyīyuèqǐyì”zhōngcǎiyòngdefāngfǎqùzhànlǐnghuáshā.
 1	他	他	PRON	PRP	Person=3	9	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -2593,6 +2675,7 @@
 32	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s83
+# parallel_id = zhgsd/dev83
 # text = 这是红军开战以来最接近华沙的时刻，可是形势即将逆转。
 # translit = zhèshìhóngjūnkāizhànyǐláizuìjiējìnhuáshādeshíkè,kěshìxíngshìjíjiāng逆zhuǎn.
 1	这	这	PRON	PRD	_	10	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -2614,6 +2697,7 @@
 17	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s84
+# parallel_id = zhgsd/dev84
 # text = 但哈利·华纳表示反对意见：“谁会想要听到演员开口说话呢？”。
 # translit = dànhālì·huánàbiǎoshìfǎnduìyìjiàn:“shuíhuìxiǎngyàotīngdàoyǎnyuánkāikǒushuōhuàne?”.
 1	但	但	SCONJ	RB	_	5	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -2639,6 +2723,7 @@
 21	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s85
+# parallel_id = zhgsd/dev85
 # text = 在山姆·华纳逝世后，杰克·华纳成为制作部门的领导者，但杰克·华纳也因兄长逝世而遭受打击。
 # translit = zàishānmǔ·huánàshìshìhòu,jiékè·huánàchéngwèizhìzuòbùméndelǐngdǎozhě,dànjiékè·huánàyěyīnxiōngzhǎngshìshì'érzāoshòudǎjī.
 1	在	在	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -2673,6 +2758,7 @@
 30	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s86
+# parallel_id = zhgsd/dev86
 # text = 1923年，威廉·莱昂·麦肯齐·金的联邦自由党政府，通过1923年华人移民法案，完全禁止了华人移民。
 # translit = 1923nián,wēilián·莱'áng·màikěnqí·jīndeliánbāngzìyóudǎngzhèngfǔ,tōngguò1923niánhuárényímínfǎ'àn,wánquánjìnzhǐlehuárényímín.
 1	1923	1923	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1923|LTranslit=1923
@@ -2708,6 +2794,7 @@
 31	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s87
+# parallel_id = zhgsd/dev87
 # text = 由于加拿大在二战后签署了联合国世界人权宣言，加拿大政府必须废除与宣言抵触的排华法案。
 # translit = yóuyújiānádàzài'èrzhànhòuqiānshǔleliánhéguóshìjièrénquánxuānyán,jiānádàzhèngfǔbìxūfèichúyǔxuānyándǐchùdepáihuáfǎ'àn.
 1	由于	由于	ADP	IN	_	6	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -2737,6 +2824,7 @@
 25	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s88
+# parallel_id = zhgsd/dev88
 # text = 这些人主要居住在维多利亚、温哥华、蒙特利尔和多伦多。
 # translit = zhèxiērénzhǔyàojūzhùzàiwéiduōlìyà,wēngēhuá,méngtèlì'ěrhéduōlúnduō.
 1	这些	这些	DET	DT	_	2	det	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -2754,6 +2842,7 @@
 13	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s89
+# parallel_id = zhgsd/dev89
 # text = 2003年11月15日，法航协和飞机的一批剩余零部件和纪念品在巴黎佳士得拍卖行公开拍卖，有约13,000人到场竞投，共拍卖得320万欧元，部分拍卖品的成交价远超预期。
 # translit = 2003nián11yuè15rì,fǎhángxiéhéfēijīdeyīpīshèngyúlíngbùjiànhéjìniànpǐnzàibalíjiāshìdepāimàixínggōngkāipāimài,yǒuyuē13,000réndàochǎngjìngtóu,gòngpāimàide320wàn'ōuyuán,bùfēnpāimàipǐndechéngjiāojiàyuǎnchāoyùqī.
 1	2003	2003	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2003|LTranslit=2003
@@ -2807,6 +2896,7 @@
 49	。	。	PUNCT	.	_	35	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s90
+# parallel_id = zhgsd/dev90
 # text = 拍卖的物品包括原来存放在图卢兹市欧洲航天航空防务集团工厂仓库内的超过1000件客机零部件和机舱内装饰物品，其中包括起价为600欧元的乘客座椅、300欧元的应急氧气罩、许多银质和陶瓷餐具以及其他飞机零件，甚至包括一个起落架，并且这些拍卖物品都是从来没有被旅客使用过的。
 # translit = pāimàidewùpǐnbāokuòyuánláicúnfàngzàitú卢兹shì'ōuzhōuhángtiānhángkōngfángwujítuángōngchǎngcāngkùnèidechāoguò1000jiànkèjīlíngbùjiànhéjīcāngnèizhuāngshìwùpǐn,qízhōngbāokuòqǐjiàwèi600'ōuyuándechéngkèzuòyǐ,300'ōuyuándeyīngjíyǎngqìzhào,xǔduōyínzhìhétáocícānjùyǐjíqítāfēijīlíngjiàn,shénzhìbāokuòyīgèqǐluòjià,bìngqiězhèxiēpāimàiwùpǐndōushìcóngláiméiyǒubèilǚkèshǐyòngguòde.
 1	拍卖	拍卖	VERB	VV	_	3	acl:relcl	_	SpaceAfter=No|Translit=pāimài|LTranslit=pāimài
@@ -2889,6 +2979,7 @@
 78	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s91
+# parallel_id = zhgsd/dev91
 # text = 自此卓义峰便拥有“丐帮帮主”的外号。
 # translit = zìcǐ卓yìfēngbiànyōngyǒu“丐bāngbāngzhǔ”dewàihào.
 1	自	自	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zì|LTranslit=zì
@@ -2906,6 +2997,7 @@
 13	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s92
+# parallel_id = zhgsd/dev92
 # text = 虽则日语存在“二段音阶”的变化，但只凭这二音变化，也没有协音的可能。
 # translit = suīzérìyǔcúnzài“'èrduànyīnjiē”debiànhuà,dànzhǐpíngzhè'èryīnbiànhuà,yěméiyǒuxiéyīndekěnéng.
 1	虽则	虽则	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=suīzé|LTranslit=suīzé
@@ -2936,6 +3028,7 @@
 26	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s93
+# parallel_id = zhgsd/dev93
 # text = 从中华人民共和国建政到文化大革命结束，单县历任县长或革委会主任：
 # translit = cóngzhōnghuárénmíngònghéguójiànzhèngdàowénhuàdàgémìngjiéshù,dānxiànlìrènxiànzhǎnghuògéwěihuìzhǔrèn:
 1	从	从	ADP	IN	_	6	case	_	SpaceAfter=No|Translit=cóng|LTranslit=cóng
@@ -2960,6 +3053,7 @@
 20	：	：	PUNCT	:	_	15	punct	_	SpaceAfter=No|Translit=:|LTranslit=:
 
 # sent_id = dev-s94
+# parallel_id = zhgsd/dev94
 # text = 1960年代后，随着殖民地独立，作为“单独关税区”的非主权政治实体渐渐减少。
 # translit = 1960niándàihòu,suízhezhímíndedúlì,zuòwèi“dāndúguānshuìqū”defēizhǔquánzhèngzhìshítǐjiànjiànjiǎnshǎo.
 1	1960	1960	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1960|LTranslit=1960
@@ -2989,6 +3083,7 @@
 25	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s95
+# parallel_id = zhgsd/dev95
 # text = 尽管概念一般是一致的，两个学科已经发展出稍微不同的术语。
 # translit = jǐnguǎngàiniànyībānshìyīzhìde,liǎnggèxuékēyǐjīngfāzhǎnchūshāowēibùtóngdeshùyǔ.
 1	尽管	尽管	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=jǐnguǎn|LTranslit=jǐnguǎn
@@ -3011,6 +3106,7 @@
 18	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s96
+# parallel_id = zhgsd/dev96
 # text = 在微积分中，它们是带有平常次序的实数集的子集之间的函数，但是定义仍保持同更一般的序理论定义一样。
 # translit = zàiwēijīfēnzhōng,tāmenshìdàiyǒupíngchángcìxùdeshíshùjídezijízhījiānde函shù,dànshìdìngyìréngbǎochítónggèngyībāndexùlǐlùndìngyìyīyàng.
 1	在	在	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -3046,6 +3142,7 @@
 31	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s97
+# parallel_id = zhgsd/dev97
 # text = 国民革命军面临前后夹攻，因此下令全线撤退。
 # translit = guómíngémìngjūnmiànlínqiánhòujiāgōng,yīncǐxiàlìngquánxiànchètuì.
 1	国民	国民	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=guómín|LTranslit=guómín
@@ -3063,6 +3160,7 @@
 13	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s98
+# parallel_id = zhgsd/dev98
 # text = 2009年7月1日，南京大学2007、2008级学生由浦口校区搬迁至新建成的仙林校区。
 # translit = 2009nián7yuè1rì,nánjīngdàxué2007,2008jíxuéshēngyóu浦kǒuxiàoqūbānqiānzhìxīnjiànchéngdexianlínxiàoqū.
 1	2009	2009	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2009|LTranslit=2009
@@ -3092,6 +3190,7 @@
 25	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s99
+# parallel_id = zhgsd/dev99
 # text = 南京官话曾经长期是中国的官方语言。
 # translit = nánjīngguānhuàcéngjīngzhǎngqīshìzhōngguódeguānfāngyǔyán.
 1	南京	南京	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=nánjīng|LTranslit=nánjīng
@@ -3106,6 +3205,7 @@
 10	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s100
+# parallel_id = zhgsd/dev100
 # text = 雅语和吴语融合，逐渐形成南方的江淮官话。
 # translit = 雅yǔhé吴yǔrónghé,zhújiànxíngchéngnánfāngdejiāng淮guānhuà.
 1	雅	雅	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=雅|LTranslit=雅
@@ -3124,6 +3224,7 @@
 14	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s101
+# parallel_id = zhgsd/dev101
 # text = 南京其他重要的水体还包括从六合区流过的滁河、高淳的固城湖、溧水的石臼湖等。
 # translit = nánjīngqítāzhòngyàodeshuǐtǐháibāokuòcóngliùhéqūliúguòde滁hé,gāochúndegùchénghú,溧shuǐdeshí臼húděng.
 1	南京	南京	PROPN	NNP	_	5	nmod	_	SpaceAfter=No|Translit=nánjīng|LTranslit=nánjīng
@@ -3153,6 +3254,7 @@
 25	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s102
+# parallel_id = zhgsd/dev102
 # text = 市区除玄武湖外、还有莫愁湖、南湖、琵琶湖、前湖、紫霞湖、月牙湖等天然或人工湖泊。
 # translit = shìqūchú玄wǔhúwài,háiyǒumòchóuhú,nánhú,琵琶hú,qiánhú,zǐxiáhú,yuèyáhúděngtiānránhuòréngōnghúpō.
 1	市区	市区	NOUN	NN	_	8	nsubj	_	SpaceAfter=No|Translit=shìqū|LTranslit=shìqū
@@ -3186,6 +3288,7 @@
 29	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s103
+# parallel_id = zhgsd/dev103
 # text = 温泉是南京市主要的地热资源，著名的有汤山温泉、汤泉温泉、珍珠泉温泉等。
 # translit = wēnquánshìnánjīngshìzhǔyàodederèzīyuán,zhemíngdeyǒutāngshānwēnquán,tāngquánwēnquán,zhēnzhūquánwēnquánděng.
 1	温泉	温泉	NOUN	NN	_	8	nsubj	_	SpaceAfter=No|Translit=wēnquán|LTranslit=wēnquán
@@ -3213,6 +3316,7 @@
 23	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s104
+# parallel_id = zhgsd/dev104
 # text = 1991年南加州铁路地区管理局成立。
 # translit = 1991niánnánjiāzhōutiělùdeqūguǎnlǐjúchénglì.
 1	1991	1991	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1991|LTranslit=1991
@@ -3227,6 +3331,7 @@
 10	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s105
+# parallel_id = zhgsd/dev105
 # text = 该方案最终于2006年11月投票通过。
 # translit = gāifāng'ànzuìzhōngyú2006nián11yuètóupiàotōngguò.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -3242,6 +3347,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s106
+# parallel_id = zhgsd/dev106
 # text = 朝鲜虽然认为渤海国是本国历史，但不使用“南北国时代”这个词汇。
 # translit = cháoxiānsuīránrènwèi渤hǎiguóshìběnguólìshǐ,dànbùshǐyòng“nánběiguóshídài”zhègècíhuì.
 1	朝鲜	朝鲜	PROPN	NNP	_	12	nsubj	_	SpaceAfter=No|Translit=cháoxiān|LTranslit=cháoxiān
@@ -3266,6 +3372,7 @@
 20	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s107
+# parallel_id = zhgsd/dev107
 # text = 有人上告说刘三吾暗嘱张信等人故意以陋卷进呈。
 # translit = yǒurénshànggàoshuō刘sān吾'ànzhǔzhāngxìnděngréngùyìyǐlòujuǎnjìnchéng.
 1	有	有	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
@@ -3286,6 +3393,7 @@
 16	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s108
+# parallel_id = zhgsd/dev108
 # text = 中校威廉‧陆斯佛得（William Drayton Rutherford）是此步兵团的英勇将领之一，死于斯特拉斯堡。
 # translit = zhōngxiàowēilián‧lùsīfúde(William Drayton Rutherford)shìcǐbùbīngtuándeyīngyǒngjiānglǐngzhīyī,sǐyúsītèlāsībǎo.
 1	中校	中校	NOUN	NN	_	20	nsubj	_	SpaceAfter=No|Translit=zhōngxiào|LTranslit=zhōngxiào
@@ -3313,6 +3421,7 @@
 23	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s109
+# parallel_id = zhgsd/dev109
 # text = 南坑，位于台湾北部，为三姓公溪的支流，位于新竹市香山区中部。
 # translit = nánkēng,wèiyútáiwānběibù,wèisānxìnggōngxīdezhīliú,wèiyúxīnzhúshìxiāngshānqūzhōngbù.
 1	南坑	南坑	PROPN	NNP	_	14	nsubj	_	SpaceAfter=No|Translit=nánkēng|LTranslit=nánkēng
@@ -3338,6 +3447,7 @@
 21	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s110
+# parallel_id = zhgsd/dev110
 # text = 2007年5月3日，中石油高调宣称冀东南堡油田油气总储量为10.2亿吨，探明储量4.05亿吨，约为30亿桶，媒体称之为“40多年来中国石油勘探最激动人心的发现”。
 # translit = 2007nián5yuè3rì,zhōngshíyóugāodiàoxuānchēng冀dōngnánbǎoyóutiányóuqìzǒngchǔliàngwèi10.2yìdūn,tànmíngchǔliàng4.05yìdūn,yuēwèi30yìtǒng,méitǐchēngzhīwèi“40duōniánláizhōngguóshíyóukāntànzuìjīdòngrénxīndefāxiàn”.
 1	2007	2007	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2007|LTranslit=2007
@@ -3391,6 +3501,7 @@
 49	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s111
+# parallel_id = zhgsd/dev111
 # text = “文化大革命”中各级教育行政机构陷入瘫痪，1978年后恢复发展。
 # translit = “wénhuàdàgémìng”zhōnggèjíjiàoyùxíngzhèngjīgòuxiànrù瘫痪,1978niánhòuhuīfùfāzhǎn.
 1	“	“	PUNCT	``	_	4	punct	_	SpaceAfter=No|Translit=“|LTranslit=“
@@ -3414,6 +3525,7 @@
 19	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s112
+# parallel_id = zhgsd/dev112
 # text = “南曲戏文”跟宋金“北曲杂剧”有很大不同，它在表演的体制与结构上都要比杂剧来得自由，可以根据剧情需要作不同选择，具备了戏剧的特征。
 # translit = “nánqūxìwén”gēn宋jīn“běiqūzájù”yǒuhěndàbùtóng,tāzàibiǎoyǎndetǐzhìyǔjiégòushàngdōuyàobǐzájùláidezìyóu,kěyǐgēnjùjùqíngxūyàozuòbùtóngxuǎnzé,jùbèilexìjùdetèzhēng.
 1	“	“	PUNCT	``	_	3	punct	_	SpaceAfter=No|Translit=“|LTranslit=“
@@ -3463,6 +3575,7 @@
 45	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s113
+# parallel_id = zhgsd/dev113
 # text = 元朝末年发展到巅峰，明中叶后逐渐被新兴的昆山腔所替代，并演化为明清的主要戏剧----传奇。
 # translit = yuáncháomòniánfāzhǎndào巅fēng,míngzhōngyèhòuzhújiànbèixīnxìngdekūnshānqiāngsuǒtìdài,bìngyǎnhuàwèimíngqīngdezhǔyàoxìjù----chuánqí.
 1	元朝	元朝	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=yuáncháo|LTranslit=yuáncháo
@@ -3496,6 +3609,7 @@
 29	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s114
+# parallel_id = zhgsd/dev114
 # text = 理学家朱熹任漳州知府时，也曾禁止当地戏曲演出。
 # translit = lǐxuéjiā朱熹rèn漳zhōuzhīfǔshí,yěcéngjìnzhǐdāngdexìqūyǎnchū.
 1	理学	理学	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=lǐxué|LTranslit=lǐxué
@@ -3516,6 +3630,7 @@
 16	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s115
+# parallel_id = zhgsd/dev115
 # text = 特殊的地理位置，使本区成为南投市区与中兴新村来往通道，也是中寮乡北部对外主要孔道。
 # translit = tèshūdedelǐwèizhì,shǐběnqūchéngwèinántóushìqūyǔzhōngxìngxīncūnláiwǎngtōngdào,yěshìzhōng寮xiāngběibùduìwàizhǔyàokǒngdào.
 1	特殊	特殊	ADJ	JJ	_	4	amod	_	SpaceAfter=No|Translit=tèshū|LTranslit=tèshū
@@ -3545,6 +3660,7 @@
 25	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s116
+# parallel_id = zhgsd/dev116
 # text = 1946年制的宪法规定无论共和国彼此人口与经济地位，代表人数皆相同，因此可视为南联邦以齐头式平等的权力保障与联邦制政体来解决民族问题的选择。
 # translit = 1946niánzhìdexiànfǎguīdìngwúlùngònghéguóbǐcǐrénkǒuyǔjīngjìdewèi,dàibiǎorénshùjiēxiāngtóng,yīncǐkěshìwèinánliánbāngyǐqítóushìpíngděngdequánlìbǎozhàngyǔliánbāngzhìzhèngtǐláijiějuémínzúwèntídexuǎnzé.
 1	1946	1946	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1946|LTranslit=1946
@@ -3594,6 +3710,7 @@
 45	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s117
+# parallel_id = zhgsd/dev117
 # text = 地方政府官员也不再由中央指派，而改由地方选出，连联邦中央人员也是由地方派代表所组成，使得其只对选区负责，不会去考量整体联邦之利益，使得各区的地方主义逐渐增长。
 # translit = defāngzhèngfǔguānyuányěbùzàiyóuzhōngyāngzhǐpài,'érgǎiyóudefāngxuǎnchū,liánliánbāngzhōngyāngrényuányěshìyóudefāngpàidàibiǎosuǒzǔchéng,shǐdeqízhǐduìxuǎnqūfùzé,bùhuìqùkǎoliàngzhěngtǐliánbāngzhīlìyì,shǐdegèqūdedefāngzhǔyìzhújiànzēngzhǎng.
 1	地方	地方	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=defāng|LTranslit=defāng
@@ -3649,6 +3766,7 @@
 51	。	。	PUNCT	.	_	44	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s118
+# parallel_id = zhgsd/dev118
 # text = 战争结束时，狄托下令所有超过27岁的士兵复员，将军队规模缩编为一半，并按照苏联模式组成新军，在南斯拉夫的观点中，苏联红军不仅是最优秀的，更重要的是，它是一支“社会主义的军队”。
 # translit = zhànzhēngjiéshùshí,狄tuōxiàlìngsuǒyǒuchāoguò27suìdeshìbīngfùyuán,jiāngjūnduìguīmósuōbiānwèiyībàn,bìng'ànzhàosūliánmóshìzǔchéngxīnjūn,zàinánsīlāfudeguāndiǎnzhōng,sūliánhóngjūnbùjǐnshìzuìyōuxiùde,gèngzhòngyàodeshì,tāshìyīzhī“shèhuìzhǔyìdejūnduì”.
 1	战争	战争	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=zhànzhēng|LTranslit=zhànzhēng
@@ -3711,6 +3829,7 @@
 58	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s119
+# parallel_id = zhgsd/dev119
 # text = 《南极条约》于1959年12月1日，由12个国家签订，并在1961年6月23日正式执行，迄今已有50国签署。
 # translit = «nánjítiáoyuē»yú1959nián12yuè1rì,yóu12gèguójiāqiāndìng,bìngzài1961nián6yuè23rìzhèngshìzhíxíng,迄jīnyǐyǒu50guóqiānshǔ.
 1	《	《	PUNCT	(	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -3751,6 +3870,7 @@
 36	。	。	PUNCT	.	_	28	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s120
+# parallel_id = zhgsd/dev120
 # text = 从坠落的时间，或是居住在地球的时间，陨石还可以提供更多研究南极冰层环境的有用资讯。
 # translit = cóngzhuìluòdeshíjiān,huòshìjūzhùzàideqiúdeshíjiān,陨shíháikěyǐtígōnggèngduōyánjiūnánjíbīngcénghuánjìngdeyǒuyòngzīxùn.
 1	从	从	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=cóng|LTranslit=cóng
@@ -3780,6 +3900,7 @@
 25	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s121
+# parallel_id = zhgsd/dev121
 # text = 2009年5月，国务院批复同意，撤销南汇区，将其行政区域整体并入浦东新区。
 # translit = 2009nián5yuè,guówuyuànpīfùtóngyì,chèxiāonánhuìqū,jiāngqíxíngzhèngqūyùzhěngtǐbìngrù浦dōngxīnqū.
 1	2009	2009	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=2009|LTranslit=2009
@@ -3807,6 +3928,7 @@
 23	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s122
+# parallel_id = zhgsd/dev122
 # text = 2007年，南洋商业银行转换新形象，以往是红色底，写上中英文全名的招牌，之后更换为和该公司网页相同的标志，标志后先写英文缩写，再写中文全名。
 # translit = 2007nián,nányángshāngyèyínxíngzhuǎnhuànxīnxíngxiàng,yǐwǎngshìhóngsèdǐ,xiěshàngzhōngyīngwénquánmíngdezhāopái,zhīhòugènghuànwèihégāigōngsīwǎngyèxiāngtóngdebiāozhì,biāozhìhòuxiānxiěyīngwénsuōxiě,zàixiězhōngwénquánmíng.
 1	2007	2007	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2007|LTranslit=2007
@@ -3859,6 +3981,7 @@
 48	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s123
+# parallel_id = zhgsd/dev123
 # text = 2009年8月1日接收原中银香港于中国内地业务，使分行及支行达11家及7家。
 # translit = 2009nián8yuè1rìjiēshōuyuánzhōngyínxiānggǎngyúzhōngguónèideyèwu,shǐfēnxíngjízhīxíngdá11jiājí7jiā.
 1	2009	2009	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2009|LTranslit=2009
@@ -3889,6 +4012,7 @@
 26	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s124
+# parallel_id = zhgsd/dev124
 # text = 南洋大学，是位于上海的一所大学。
 # translit = nányángdàxué,shìwèiyúshànghǎideyīsuǒdàxué.
 1	南洋	南洋	NOUN	NNB	_	2	nmod	_	SpaceAfter=No|Translit=nányáng|LTranslit=nányáng
@@ -3905,6 +4029,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s125
+# parallel_id = zhgsd/dev125
 # text = 早在40至50年代，许多中国大陆的华人远涉重洋，南下谋生。
 # translit = zǎozài40zhì50niándài,xǔduōzhōngguódàlùdehuárényuǎnshèzhòngyáng,nánxiàmóushēng.
 1	早	早	ADV	RB	_	6	advmod	_	SpaceAfter=No|Translit=zǎo|LTranslit=zǎo
@@ -3927,6 +4052,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s126
+# parallel_id = zhgsd/dev126
 # text = 研讨会和讲座可以享用多媒体演示、视频会议和同时由数个不同地点的通讯的设备的支持。
 # translit = yántǎohuìhéjiǎngzuòkěyǐxiǎngyòngduōméitǐyǎnshì,shìpínhuìyìhétóngshíyóushùgèbùtóngdediǎndetōngxùndeshèbèidezhīchí.
 1	研讨	研讨	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=yántǎo|LTranslit=yántǎo
@@ -3957,6 +4083,7 @@
 26	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s127
+# parallel_id = zhgsd/dev127
 # text = 2005年，南洋酒店进行了大规模的装修工程。
 # translit = 2005nián,nányángjiǔdiànjìnxíngledàguīmódezhuāngxiūgōngchéng.
 1	2005	2005	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2005|LTranslit=2005
@@ -3974,6 +4101,7 @@
 13	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s128
+# parallel_id = zhgsd/dev128
 # text = 大殿原为明代建筑，在文化大革命期间被毁，1989年重建。
 # translit = dàdiànyuánwèimíngdàijiànzhù,zàiwénhuàdàgémìngqījiānbèihuǐ,1989niánzhòngjiàn.
 1	大殿	大殿	NOUN	NN	_	17	nsubj	_	SpaceAfter=No|Translit=dàdiàn|LTranslit=dàdiàn
@@ -3996,6 +4124,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s129
+# parallel_id = zhgsd/dev129
 # text = 山上有一座小亭，名为浴日亭，是观望海上日出之地。
 # translit = shānshàngyǒuyīzuòxiǎotíng,míngwèi浴rìtíng,shìguānwànghǎishàngrìchūzhīde.
 1	山上	山上	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=shānshàng|LTranslit=shānshàng
@@ -4019,6 +4148,7 @@
 19	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s130
+# parallel_id = zhgsd/dev130
 # text = 南调是台铁纵贯线因应铁路电气化所兴建的客车调车场，1974年10月动工、1977年12月17日启用。
 # translit = nándiàoshìtáitiězòngguànxiànyīnyīngtiělùdiànqìhuàsuǒxìngjiàndekèchēdiàochēchǎng,1974nián10yuèdònggōng,1977nián12yuè17rìqǐyòng.
 1	南调	南调	PROPN	NNP	_	21	nsubj	_	SpaceAfter=No|Translit=nándiào|LTranslit=nándiào
@@ -4053,6 +4183,7 @@
 30	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s131
+# parallel_id = zhgsd/dev131
 # text = 场内设有电力机车检修厂设备、洗车台，以及包含台北机务段、台北检车段、餐旅服务总所等单位的综合办公大楼。
 # translit = chǎngnèishèyǒudiànlìjīchējiǎnxiūchǎngshèbèi,xǐchētái,yǐjíbāohántáiběijīwuduàn,táiběijiǎnchēduàn,cānlǚfúwuzǒngsuǒděngdānwèidezōnghébàngōngdàlóu.
 1	场内	场内	NOUN	NN	_	2	obl	_	SpaceAfter=No|Translit=chǎngnèi|LTranslit=chǎngnèi
@@ -4088,6 +4219,7 @@
 31	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s132
+# parallel_id = zhgsd/dev132
 # text = 中国境内流域面积3354.7平方公里。
 # translit = zhōngguójìngnèiliúyùmiànjī3354.7píngfānggōnglǐ.
 1	中国	中国	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=zhōngguó|LTranslit=zhōngguó
@@ -4099,6 +4231,7 @@
 7	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s133
+# parallel_id = zhgsd/dev133
 # text = 部分特色单位更另有平台、天台，甚至设有私人游泳池。
 # translit = bùfēntèsèdānwèigènglìngyǒupíngtái,tiāntái,shénzhìshèyǒusīrényóuyǒngchí.
 1	部分	部分	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=bùfēn|LTranslit=bùfēn
@@ -4118,6 +4251,7 @@
 15	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s134
+# parallel_id = zhgsd/dev134
 # text = 1923年，学校又更名为国立北京航空学校，隶属于由航空事务处扩组而成的航空署。
 # translit = 1923nián,xuéxiàoyòugèngmíngwèiguólìběijīnghángkōngxuéxiào,lìshǔyúyóuhángkōngshìwuchùkuòzǔ'érchéngdehángkōngshǔ.
 1	1923	1923	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1923|LTranslit=1923
@@ -4148,6 +4282,7 @@
 26	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s135
+# parallel_id = zhgsd/dev135
 # text = 同年9月，南苑航空学校正式开学，秦国镛任首任校长，王鄂任教育长，厉汝燕任飞行主任教官。
 # translit = tóngnián9yuè,nán苑hángkōngxuéxiàozhèngshìkāixué,秦guó镛rènshǒurènxiàozhǎng,wáng鄂rènjiàoyùzhǎng,lì汝yànrènfēixíngzhǔrènjiàoguān.
 1	同年	同年	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=tóngnián|LTranslit=tóngnián
@@ -4181,6 +4316,7 @@
 29	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s136
+# parallel_id = zhgsd/dev136
 # text = 梵语jambu，为树名，即阎浮树，是一种生长在印度南方的大型乔木。
 # translit = 梵yǔjambu,wèishùmíng,jí阎fúshù,shìyīzhǒngshēngzhǎngzàiyìndùnánfāngdedàxíng乔mù.
 1	梵	梵	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=梵|LTranslit=梵
@@ -4206,6 +4342,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s137
+# parallel_id = zhgsd/dev137
 # text = 2008年11月，南车四方机车车辆股份获国家发改委批准，设立“高速列车系统集成国家工程实验室”，主力建设包含高速列车系统集成、转向架综合、电磁兼容综合、车体综合和环境综合等研发试验设施的高速列车研发实验基地。。
 # translit = 2008nián11yuè,nánchēsìfāngjīchēchēliànggǔfènhuòguójiāfāgǎiwěipīzhǔn,shèlì“gāosùlièchēxìtǒngjíchéngguójiāgōngchéngshíyànshì”,zhǔlìjiànshèbāohángāosùlièchēxìtǒngjíchéng,zhuǎnxiàngjiàzōnghé,diàncíjiānróngzōnghé,chētǐzōnghéhéhuánjìngzōnghéděngyánfāshìyànshèshīdegāosùlièchēyánfāshíyànjīde..
 1	2008	2008	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=2008|LTranslit=2008
@@ -4269,6 +4406,7 @@
 59	。。	。。	PUNCT	...	_	30	punct	_	SpaceAfter=No|Translit=..|LTranslit=..
 
 # sent_id = dev-s138
+# parallel_id = zhgsd/dev138
 # text = 另外，罗马教廷于1844年在靳岗设立的天主教南阳教区，曾长期掌管河南全省的教务，法国人安巴都为首任主教，现存有靳岗天主教堂。
 # translit = lìngwài,luōmǎjiàotíngyú1844niánzài靳gǎngshèlìdetiānzhǔjiàonányángjiàoqū,céngzhǎngqīzhǎngguǎnhénánquánshěngdejiàowu,fǎguórén'ānbadōuwèishǒurènzhǔjiào,xiàncúnyǒu靳gǎngtiānzhǔjiàotáng.
 1	另外	另外	ADV	RB	_	19	advmod	_	SpaceAfter=No|Translit=lìngwài|LTranslit=lìngwài
@@ -4311,6 +4449,7 @@
 38	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s139
+# parallel_id = zhgsd/dev139
 # text = 希比拉任命托尔托萨主教巴塞洛缪为市政官。
 # translit = xībǐlārènmìngtuō'ěrtuōsàzhǔjiàobasāiluò缪wèishìzhèngguān.
 1	希比拉	希比拉	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=xībǐlā|LTranslit=xībǐlā
@@ -4324,6 +4463,7 @@
 9	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s140
+# parallel_id = zhgsd/dev140
 # text = 2011年10月，公司决定退出出口市场，为减少50%的产能，工厂关闭了位于肯布兰两个高炉之一的第6号高炉。
 # translit = 2011nián10yuè,gōngsījuédìngtuìchūchūkǒushìchǎng,wèijiǎnshǎo50%dechǎnnéng,gōngchǎngguānbìlewèiyúkěnbùlánliǎnggègāolúzhīyīdedì6hàogāolú.
 1	2011	2011	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=2011|LTranslit=2011
@@ -4361,6 +4501,7 @@
 33	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s141
+# parallel_id = zhgsd/dev141
 # text = 总面积55平方公里，人口2388人，人口密度43.4人/平方公里（2009年）。
 # translit = zǒngmiànjī55píngfānggōnglǐ,rénkǒu2388rén,rénkǒumìdù43.4rén/píngfānggōnglǐ(2009nián).
 1	总	总	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=zǒng|LTranslit=zǒng
@@ -4385,6 +4526,7 @@
 20	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s142
+# parallel_id = zhgsd/dev142
 # text = 交战后，一切如诸葛亮所安排般发生。
 # translit = jiāozhànhòu,yīqièrúzhū葛liàngsuǒ'ānpáibānfāshēng.
 1	交战	交战	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=jiāozhàn|LTranslit=jiāozhàn
@@ -4401,6 +4543,7 @@
 12	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s143
+# parallel_id = zhgsd/dev143
 # text = 博杰普尔语也在盖亚那、苏利南、斐济、特立尼达和多巴哥、模里西斯使用，可以说成在世界多个州份均有人使用。
 # translit = bójiépǔ'ěryǔyězàigàiyànà,sūlìnán,斐jì,tèlìnídáhéduōbagē,mólǐxisīshǐyòng,kěyǐshuōchéngzàishìjièduōgèzhōufènjūnyǒurénshǐyòng.
 1	博杰普尔	博杰普尔	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=bójiépǔ'ěr|LTranslit=bójiépǔ'ěr
@@ -4434,6 +4577,7 @@
 29	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s144
+# parallel_id = zhgsd/dev144
 # text = 1400年的庆典吸引了许多法国人。
 # translit = 1400niándeqìngdiǎnxīyǐnlexǔduōfǎguórén.
 1	1400	1400	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1400|LTranslit=1400
@@ -4448,6 +4592,7 @@
 10	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s145
+# parallel_id = zhgsd/dev145
 # text = 近年来，肯亚女子长距离田径项目也开始崭露头角，而这些女运动员们也多为卡伦金人。
 # translit = jìnniánlái,kěnyànǚzizhǎngjùlítiánjìngxiàngmùyěkāishǐzhǎnlùtóujiǎo,'érzhèxiēnǚyùndòngyuánmenyěduōwèikǎlúnjīnrén.
 1	近年	近年	NOUN	NN	_	11	nmod:tmod	_	SpaceAfter=No|Translit=jìnnián|LTranslit=jìnnián
@@ -4477,6 +4622,7 @@
 25	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s146
+# parallel_id = zhgsd/dev146
 # text = 建设该中心的目的是给本州制药企业，GMP工厂提供合格的人员资源。
 # translit = jiànshègāizhōngxīndemùdeshìgěiběnzhōuzhìyàoqǐyè,GMPgōngchǎngtígōnghégéderényuánzīyuán.
 1	建设	建设	VERB	VV	_	5	acl:relcl	_	SpaceAfter=No|Translit=jiànshè|LTranslit=jiànshè
@@ -4500,6 +4646,7 @@
 19	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s147
+# parallel_id = zhgsd/dev147
 # text = 施米特于1888年生于威斯特伐里亚普勒腾贝格的一个天主教家庭。
 # translit = shīmǐtèyú1888niánshēngyúwēisītèfálǐyàpǔlēiténgbèigédeyīgètiānzhǔjiàojiātíng.
 1	施米特	施米特	PROPN	NNP	_	5	nsubj	_	SpaceAfter=No|Translit=shīmǐtè|LTranslit=shīmǐtè
@@ -4519,6 +4666,7 @@
 15	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s148
+# parallel_id = zhgsd/dev148
 # text = 理察在小时候就对音乐很有兴趣，并且被培养为钢琴奇才。
 # translit = lǐcházàixiǎoshíhoujiùduìyīnlèhěnyǒuxìngqù,bìngqiěbèipéiyǎngwèigāngqínqícái.
 1	理察	理察	PROPN	NNP	_	14	nsubj:pass	_	SpaceAfter=No|Translit=lǐchá|LTranslit=lǐchá
@@ -4541,6 +4689,7 @@
 18	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s149
+# parallel_id = zhgsd/dev149
 # text = 他的统治时间是从约1388年至1420年，其中从1400年至1405年他的统治被帖木儿帝国中断。
 # translit = tādetǒngzhìshíjiānshìcóngyuē1388niánzhì1420nián,qízhōngcóng1400niánzhì1405niántādetǒngzhìbèi帖mùrdìguózhōngduàn.
 1	他	他	PRON	PRP	Person=3	4	det	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -4573,6 +4722,7 @@
 28	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s150
+# parallel_id = zhgsd/dev150
 # text = 苏联本来曾想再分设一种1134A和一种1134B反潜舰，也曾想将反潜的任务都交给1124型小型反潜舰，但是发现小型舰适应不了远海任务于是还是发展了大型反潜舰。
 # translit = sūliánběnláicéngxiǎngzàifēnshèyīzhǒng1134Ahéyīzhǒng1134Bfǎnqiánjiàn,yěcéngxiǎngjiāngfǎnqiánderènwudōujiāogěi1124xíngxiǎoxíngfǎnqiánjiàn,dànshìfāxiànxiǎoxíngjiànshìyīngbùleyuǎnhǎirènwuyúshìháishìfāzhǎnledàxíngfǎnqiánjiàn.
 1	苏联	苏联	PROPN	NNP	_	43	nsubj	_	SpaceAfter=No|Translit=sūlián|LTranslit=sūlián
@@ -4625,6 +4775,7 @@
 48	。	。	PUNCT	.	_	43	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s151
+# parallel_id = zhgsd/dev151
 # text = 卡拉胶是食品添加剂的一种。
 # translit = kǎlājiāoshìshípǐntiānjiājìdeyīzhǒng.
 1	卡拉	卡拉	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=kǎlā|LTranslit=kǎlā
@@ -4639,6 +4790,7 @@
 10	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s152
+# parallel_id = zhgsd/dev152
 # text = 他生于第三纪元1259年，战死于1447年，享年188岁。
 # translit = tāshēngyúdìsānjìyuán1259nián,zhànsǐyú1447nián,xiǎngnián188suì.
 1	他	他	PRON	PRP	Person=3	14	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -4660,6 +4812,7 @@
 17	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s153
+# parallel_id = zhgsd/dev153
 # text = 卡斯科奎姆河（Kuskokwim River）是美国阿拉斯加州南部的一条河流。
 # translit = kǎsīkē奎mǔhé(Kuskokwim River)shìměiguó'ālāsījiāzhōunánbùdeyītiáohéliú.
 1	卡斯科奎姆	卡斯科奎姆	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=kǎsīkē奎mǔ|LTranslit=kǎsīkē奎mǔ
@@ -4680,6 +4833,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s154
+# parallel_id = zhgsd/dev154
 # text = 他的哥哥洛马纳·卢阿卢阿亦曾效力纽卡素。
 # translit = tādegēgēluòmǎnà·卢'ā卢'āyìcéngxiàolìniǔkǎsù.
 1	他	他	PRON	PRP	Person=3	3	det	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -4695,6 +4849,7 @@
 11	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s155
+# parallel_id = zhgsd/dev155
 # text = 1914年她的父母离婚，母亲带着三个孩子来到了洛杉矶。
 # translit = 1914niántādefùmǔlíhūn,mǔqīndàizhesāngèháiziláidàoleluòshān矶.
 1	1914	1914	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1914|LTranslit=1914
@@ -4716,6 +4871,7 @@
 17	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s156
+# parallel_id = zhgsd/dev156
 # text = 她是三个孩子中最小的，还有两个哥哥。
 # translit = tāshìsāngèháizizhōngzuìxiǎode,háiyǒuliǎnggègēgē.
 1	她	她	PRON	PRP	Person=3	11	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -4735,6 +4891,7 @@
 15	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s157
+# parallel_id = zhgsd/dev157
 # text = 他也是西西里国王（称卡洛二世）和那不勒斯国王（称卡洛五世），勃艮第伯爵（1665年-1678年）、夏洛莱伯爵（1665年-1684年）。
 # translit = tāyěshìxixilǐguówáng(chēngkǎluò'èrshì)hénàbùlēisīguówáng(chēngkǎluòwǔshì),bó艮dìbójué(1665nián-1678nián),xiàluò莱bójué(1665nián-1684nián).
 1	他	他	PRON	PRP	Person=3	4	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -4777,6 +4934,7 @@
 38	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s158
+# parallel_id = zhgsd/dev158
 # text = 利奥波德一世与玛格丽塔只有一个女儿：玛利亚·安东妮娅，她就是巴伐利亚的约瑟夫·斐迪南亲王之母。
 # translit = lì'àobōdéyīshìyǔmǎgélìtǎzhǐyǒuyīgènǚr:mǎlìyà·'āndōng妮娅,tājiùshìbafálìyàdeyuē瑟fu·斐dínánqīnwángzhīmǔ.
 1	利奥波德	利奥波德	PROPN	NNP	_	6	nsubj	_	SpaceAfter=No|Translit=lì'àobōdé|LTranslit=lì'àobōdé
@@ -4806,6 +4964,7 @@
 25	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s159
+# parallel_id = zhgsd/dev159
 # text = 1970年因为他对维也纳音乐贡献卓著而荣获金牌大奖章，并享受奥地利音乐总监督的殊荣。
 # translit = 1970niányīnwèitāduìwéiyěnàyīnlègòngxiàn卓zhe'érrónghuòjīnpáidàjiǎngzhāng,bìngxiǎngshòu'àodelìyīnlèzǒngjiāndūdeshūróng.
 1	1970	1970	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1970|LTranslit=1970
@@ -4834,6 +4993,7 @@
 24	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s160
+# parallel_id = zhgsd/dev160
 # text = 但人们经常将这两个族群有紧密的联系，但实际上两者讲的是不同的语言。
 # translit = dànrénmenjīngchángjiāngzhèliǎnggèzúqúnyǒujǐnmìdeliánxì,dànshíjìshàngliǎngzhějiǎngdeshìbùtóngdeyǔyán.
 1	但	但	SCONJ	RB	_	9	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -4863,6 +5023,7 @@
 25	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s161
+# parallel_id = zhgsd/dev161
 # text = 2005年球场曾遭受洪水淹浸。
 # translit = 2005niánqiúchǎngcéngzāoshòuhóngshuǐyānjìn.
 1	2005	2005	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2005|LTranslit=2005
@@ -4875,6 +5036,7 @@
 8	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s162
+# parallel_id = zhgsd/dev162
 # text = 卡莱尔是拥有简洁而历史意义重大的城市，该地有一座城堡、博物馆、大教堂以及不完整的城墙。
 # translit = kǎ莱'ěrshìyōngyǒujiǎnjié'érlìshǐyìyìzhòngdàdechéngshì,gāideyǒuyīzuòchéngbǎo,bówùguǎn,dàjiàotángyǐjíbùwánzhěngdechéngqiáng.
 1	卡莱尔	卡莱尔	PROPN	NNP	_	10	nsubj	_	SpaceAfter=No|Translit=kǎ莱'ěr|LTranslit=kǎ莱'ěr
@@ -4907,6 +5069,7 @@
 28	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s163
+# parallel_id = zhgsd/dev163
 # text = 而丘吉尔则同意扩大在缅甸的军事行动以稳固蒋介石在中国的地位。
 # translit = 'érqiūjí'ěrzétóngyìkuòdàzài缅diāndejūnshìxíngdòngyǐwěngù蒋jièshízàizhōngguódedewèi.
 1	而	而	SCONJ	RB	_	4	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -4930,6 +5093,7 @@
 19	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s164
+# parallel_id = zhgsd/dev164
 # text = 这类动画较多以手绘的平面图片进行拍摄，通常具有连续或单元剧情，且大部份是以孩童为主要受众的动画作品。
 # translit = zhèlèidònghuàjiàoduōyǐshǒuhuìdepíngmiàntúpiànjìnxíngpāishè,tōngchángjùyǒuliánxùhuòdānyuánjùqíng,qiědàbùfènshìyǐháitóngwèizhǔyàoshòuzhòngdedònghuàzuòpǐn.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -4967,6 +5131,7 @@
 33	。	。	PUNCT	.	_	32	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s165
+# parallel_id = zhgsd/dev165
 # text = 从历史记载上看，回到罗马的卡里努斯，出手阔绰，举办了盛大的赛会等活动。
 # translit = cónglìshǐjìzàishàngkàn,huídàoluōmǎdekǎlǐnǔsī,chūshǒukuò绰,jǔbànleshèngdàdesàihuìděnghuódòng.
 1	从	从	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=cóng|LTranslit=cóng
@@ -4993,6 +5158,7 @@
 22	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s166
+# parallel_id = zhgsd/dev166
 # text = 除了他的眼罩，贾霸最出名的就是他的大勾手投篮，其他球员几乎很难防守其勾手，他也因此被称为“天勾贾霸”。
 # translit = chúletādeyǎnzhào,贾bàzuìchūmíngdejiùshìtādedàgōushǒutóulán,qítāqiúyuánjǐhuhěnnánfángshǒuqígōushǒu,tāyěyīncǐbèichēngwèi“tiāngōu贾bà”.
 1	除	除	VERB	VV	_	11	advcl	_	SpaceAfter=No|Translit=chú|LTranslit=chú
@@ -5034,6 +5200,7 @@
 37	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s167
+# parallel_id = zhgsd/dev167
 # text = 10月18日，孙中山改任黄复生、卢师谛为四川靖国联军总司令、副司令，石青阳为川北招讨使，并电嘱他们同唐继尧合作。
 # translit = 10yuè18rì,sūnzhōngshāngǎirènhuángfùshēng,卢shī谛wèisìchuān靖guóliánjūnzǒngsīlìng,fùsīlìng,shíqīngyángwèichuānběizhāotǎoshǐ,bìngdiànzhǔtāmentóngtángjì尧hézuò.
 1	10	10	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=10|LTranslit=10
@@ -5076,6 +5243,7 @@
 38	。	。	PUNCT	.	_	32	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s168
+# parallel_id = zhgsd/dev168
 # text = 1917年8月，孙中山成立护法军政府，任大元帅。
 # translit = 1917nián8yuè,sūnzhōngshānchénglìhùfǎjūnzhèngfǔ,rèndàyuánshuài.
 1	1917	1917	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1917|LTranslit=1917
@@ -5096,6 +5264,7 @@
 16	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s169
+# parallel_id = zhgsd/dev169
 # text = 桥东头则立有乾隆帝题写的“卢沟晓月”碑。
 # translit = qiáodōngtóuzélìyǒu乾lóngdìtíxiěde“卢gōuxiǎoyuè”bēi.
 1	桥	桥	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=qiáo|LTranslit=qiáo
@@ -5114,6 +5283,7 @@
 14	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s170
+# parallel_id = zhgsd/dev170
 # text = 总面积8平方公里，总人口128人（2001年），人口密度16人/平方公里。
 # translit = zǒngmiànjī8píngfānggōnglǐ,zǒngrénkǒu128rén(2001nián),rénkǒumìdù16rén/píngfānggōnglǐ.
 1	总	总	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=zǒng|LTranslit=zǒng
@@ -5139,6 +5309,7 @@
 21	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s171
+# parallel_id = zhgsd/dev171
 # text = 后来印刷的范围扩大到其他经典。
 # translit = hòuláiyìnshuādefànwéikuòdàdàoqítājīngdiǎn.
 1	后来	后来	NOUN	NN	_	5	nmod:tmod	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -5152,6 +5323,7 @@
 9	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s172
+# parallel_id = zhgsd/dev172
 # text = 印度是世界上产妇死亡率最高的国家，这和印度代孕产业的发展不无关系。
 # translit = yìndùshìshìjièshàngchǎnfùsǐwánglǜzuìgāodeguójiā,zhèhéyìndùdài孕chǎnyèdefāzhǎnbùwúguānxì.
 1	印度	印度	PROPN	NNP	_	10	nsubj	_	SpaceAfter=No|Translit=yìndù|LTranslit=yìndù
@@ -5178,6 +5350,7 @@
 22	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s173
+# parallel_id = zhgsd/dev173
 # text = 东欧，包括乌克兰、立陶宛和白俄罗斯等东欧国家一些生活艰难的女性通过出售卵子维生。
 # translit = dōng'ōu,bāokuòwūkèlán,lìtáo宛hébái'éluōsīděngdōng'ōuguójiāyīxiēshēnghuójiānnándenǚxìngtōngguòchūshòuluǎnziwéishēng.
 1	东	东	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=dōng|LTranslit=dōng
@@ -5205,6 +5378,7 @@
 23	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s174
+# parallel_id = zhgsd/dev174
 # text = 选择婴儿性别在印度属于违法。
 # translit = xuǎnzéyīngrxìngbiézàiyìndùshǔyúwéifǎ.
 1	选择	选择	VERB	VV	_	6	csubj	_	SpaceAfter=No|Translit=xuǎnzé|LTranslit=xuǎnzé
@@ -5218,6 +5392,7 @@
 9	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s175
+# parallel_id = zhgsd/dev175
 # text = 印戒细胞癌可以通过免疫组织化学进行分类。
 # translit = yìnjièxìbāo'áikěyǐtōngguòmiǎnyìzǔzhīhuàxuéjìnxíngfēnlèi.
 1	印戒	印戒	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=yìnjiè|LTranslit=yìnjiè
@@ -5233,6 +5408,7 @@
 11	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s176
+# parallel_id = zhgsd/dev176
 # text = 法国地质学家Gromaget（1934）在研究越南的地层时，首次提出印支运动的概念。
 # translit = fǎguódezhìxuéjiāGromaget(1934)zàiyánjiūyuènándedecéngshí,shǒucìtíchūyìnzhīyùndòngdegàiniàn.
 1	法国	法国	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=fǎguó|LTranslit=fǎguó
@@ -5259,6 +5435,7 @@
 22	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s177
+# parallel_id = zhgsd/dev177
 # text = 随后，数个铁路公司将其网路扩展到印第安纳波利斯，并修筑了多个车站。
 # translit = suíhòu,shùgètiělùgōngsījiāngqíwǎnglùkuòzhǎndàoyìndì'ānnàbōlìsī,bìngxiūzhùleduōgèchēzhàn.
 1	随后	随后	ADV	RB	_	16	advmod	_	SpaceAfter=No|Translit=suíhòu|LTranslit=suíhòu
@@ -5284,6 +5461,7 @@
 21	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s178
+# parallel_id = zhgsd/dev178
 # text = 教学管理中，以深化课堂教学改革、转变教学方式、打造高效课堂为核心，不断提高教学效率和教学效益。
 # translit = jiàoxuéguǎnlǐzhōng,yǐshēnhuàkètángjiàoxuégǎigé,zhuǎnbiànjiàoxuéfāngshì,dǎzàogāoxiàokètángwèihéxīn,bùduàntígāojiàoxuéxiàolǜhéjiàoxuéxiàoyì.
 1	教学	教学	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=jiàoxué|LTranslit=jiàoxué
@@ -5316,6 +5494,7 @@
 28	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s179
+# parallel_id = zhgsd/dev179
 # text = 上述款项可维持本优惠4个月，另加2012年优惠余额可维持优惠再多5个月，共可维持优惠9个月，至2014年3月31日。
 # translit = shàngshùkuǎnxiàngkěwéichíběnyōu惠4gèyuè,lìngjiā2012niányōu惠yú'ékěwéichíyōu惠zàiduō5gèyuè,gòngkěwéichíyōu惠9gèyuè,zhì2014nián3yuè31rì.
 1	上述	上述	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=shàngshù|LTranslit=shàngshù
@@ -5360,6 +5539,7 @@
 40	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s180
+# parallel_id = zhgsd/dev180
 # text = 优惠期内，乘客乘坐港铁（重铁路线，机场快线及东铁线头等除外）、轻铁或者港铁巴士，每第二程即获九折优惠。
 # translit = yōu惠qīnèi,chéngkèchéngzuògǎngtiě(zhòngtiělùxiàn,jīchǎngkuàixiànjídōngtiěxiàntóuděngchúwài),qīngtiěhuòzhěgǎngtiěbashì,měidì'èrchéngjíhuòjiǔzhéyōu惠.
 1	优惠	优惠	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=yōu惠|LTranslit=yōu惠
@@ -5397,6 +5577,7 @@
 33	。	。	PUNCT	.	_	30	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s181
+# parallel_id = zhgsd/dev181
 # text = 港铁公司营运的服务当中，如果有31分钟或以上的延误，而延误是因为港铁营运过程所导致，港铁公司需拨出款项，透过本优惠回馈乘客。
 # translit = gǎngtiěgōngsīyíngyùndefúwudāngzhōng,rúguǒyǒu31fēnzhōnghuòyǐshàngdeyánwù,'éryánwùshìyīnwèigǎngtiěyíngyùnguòchéngsuǒdǎozhì,gǎngtiěgōngsīxūbōchūkuǎnxiàng,tòuguòběnyōu惠huí馈chéngkè.
 1	港铁	港铁	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=gǎngtiě|LTranslit=gǎngtiě
@@ -5439,6 +5620,7 @@
 38	。	。	PUNCT	.	_	36	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s182
+# parallel_id = zhgsd/dev182
 # text = 卷花丹属（学名：Scorpiothyrsus）是野牡丹科下的一个属，为直立亚灌木植物。
 # translit = juǎnhuādānshǔ(xuémíng:Scorpiothyrsus)shìyěmǔdānkēxiàdeyīgèshǔ,wèizhílìyàguànmùzhíwù.
 1	卷花丹	卷花丹	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=juǎnhuādān|LTranslit=juǎnhuādān
@@ -5465,6 +5647,7 @@
 22	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s183
+# parallel_id = zhgsd/dev183
 # text = 铁路网和公路隧道位于抬高的拉德芳斯广场下方。
 # translit = tiělùwǎnghégōnglùsuìdàowèiyútáigāodelādé芳sīguǎngchǎngxiàfāng.
 1	铁路	铁路	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=tiělù|LTranslit=tiělù
@@ -5482,6 +5665,7 @@
 13	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s184
+# parallel_id = zhgsd/dev184
 # text = 原驼是南美洲最大的野生哺乳动物之一。
 # translit = yuántuoshìnánměizhōuzuìdàdeyěshēngbǔrǔdòngwùzhīyī.
 1	原驼	原驼	NOUN	NN	_	12	nsubj	_	SpaceAfter=No|Translit=yuántuo|LTranslit=yuántuo
@@ -5499,6 +5683,7 @@
 13	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s185
+# parallel_id = zhgsd/dev185
 # text = 它们只会从仙人掌中吸取养份。
 # translit = tāmenzhǐhuìcóngxianrénzhǎngzhōngxīqǔyǎngfèn.
 1	它们	它	PRON	PRP	Number=Plur|Person=3	7	nsubj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -5512,6 +5697,7 @@
 9	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s186
+# parallel_id = zhgsd/dev186
 # text = 这五篇散文与在北京创作的另五篇散文就构成了《朝花夕拾》的全部。
 # translit = zhèwǔpiānsànwényǔzàiběijīngchuàngzuòdelìngwǔpiānsànwénjiùgòuchéngle«cháohuāxīshi»dequánbù.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -5541,6 +5727,7 @@
 25	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s187
+# parallel_id = zhgsd/dev187
 # text = 2011年厦门高崎国际机场年旅客吞吐量突破1575万人次，列世界百强机场第93位；旅客吞吐量列国内民航机场第11位，货邮吞吐量列国内民航机场第9位。
 # translit = 2011niánshàméngāoqíguójìjīchǎngniánlǚkètūntǔliàngtūpò1575wànréncì,lièshìjièbǎiqiángjīchǎngdì93wèi;lǚkètūntǔliànglièguónèimínhángjīchǎngdì11wèi,huòyóutūntǔliànglièguónèimínhángjīchǎngdì9wèi.
 1	2011	2011	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2011|LTranslit=2011
@@ -5587,6 +5774,7 @@
 42	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s188
+# parallel_id = zhgsd/dev188
 # text = 世界三大观赏树厦门园林植物园种植有世界三大观赏树：中国金钱松，日本金松，日本南洋杉
 # translit = shìjièsāndàguānshǎngshùshàményuánlínzhíwùyuánzhǒngzhíyǒushìjièsāndàguānshǎngshù:zhōngguójīnqiánsōng,rìběnjīnsōng,rìběnnányángshān
 1	世界	世界	NOUN	NN	_	5	nmod	_	SpaceAfter=No|Translit=shìjiè|LTranslit=shìjiè
@@ -5613,6 +5801,7 @@
 22	日本南洋杉	日本南洋杉	NOUN	NN	_	18	conj	_	SpaceAfter=No|Translit=rìběnnányángshān|LTranslit=rìběnnányángshān
 
 # sent_id = dev-s189
+# parallel_id = zhgsd/dev189
 # text = 厦门港是中国沿海主要港口之一，是中国综合运输体系的重要枢纽、集装箱运输干线港、东南沿海的区域性枢纽港口、对台航运主要口岸。
 # translit = shàméngǎngshìzhōngguóyánhǎizhǔyàogǎngkǒuzhīyī,shìzhōngguózōnghéyùnshūtǐxìdezhòngyàoshūniǔ,jízhuāngxiāngyùnshūgànxiàngǎng,dōngnányánhǎideqūyùxìngshūniǔgǎngkǒu,duìtáihángyùnzhǔyàokǒu'àn.
 1	厦门	厦门	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=shàmén|LTranslit=shàmén
@@ -5656,6 +5845,7 @@
 39	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s190
+# parallel_id = zhgsd/dev190
 # text = 此外，本人十分善长游戏，因此作品中常见到这样的题材。
 # translit = cǐwài,běnrénshífēnshànzhǎngyóuxì,yīncǐzuòpǐnzhōngchángjiàndàozhèyàngdetícái.
 1	此外	此外	NOUN	NN	_	5	obl	_	SpaceAfter=No|Translit=cǐwài|LTranslit=cǐwài
@@ -5677,6 +5867,7 @@
 17	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s191
+# parallel_id = zhgsd/dev191
 # text = 1994年3月13日，612与722线合并成720线（友爱至天瑞），自此720及506线同时以本站为终点站。
 # translit = 1994nián3yuè13rì,612yǔ722xiànhébìngchéng720xiàn(you'àizhìtiānruì),zìcǐ720jí506xiàntóngshíyǐběnzhànwèizhōngdiǎnzhàn.
 1	1994	1994	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1994|LTranslit=1994
@@ -5715,6 +5906,7 @@
 34	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s192
+# parallel_id = zhgsd/dev192
 # text = 目前，友邦保险在中国大陆的业务范围已经扩展到北京市、广东省、江苏省、深圳市。
 # translit = mùqián,youbāngbǎoxiǎnzàizhōngguódàlùdeyèwufànwéiyǐjīngkuòzhǎndàoběijīngshì,guǎngdōngshěng,jiāngsūshěng,shēn圳shì.
 1	目前	目前	NOUN	NN	_	12	nmod:tmod	_	SpaceAfter=No|Translit=mùqián|LTranslit=mùqián
@@ -5744,6 +5936,7 @@
 25	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s193
+# parallel_id = zhgsd/dev193
 # text = 双井站位于北京市朝阳区，是北京地铁10号线和在建的7号线的一个换乘车站。
 # translit = shuāngjǐngzhànwèiyúběijīngshìcháoyángqū,shìběijīngdetiě10hàoxiànhézàijiànde7hàoxiàndeyīgèhuànchéngchēzhàn.
 1	双井	双井	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=shuāngjǐng|LTranslit=shuāngjǐng
@@ -5775,6 +5968,7 @@
 27	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s194
+# parallel_id = zhgsd/dev194
 # text = 现存的双吉寺建筑为明朝建筑，整体坐北朝南。
 # translit = xiàncúndeshuāngjísìjiànzhùwèimíngcháojiànzhù,zhěngtǐzuòběicháonán.
 1	现存	现存	VERB	VV	_	5	acl:relcl	_	SpaceAfter=No|Translit=xiàncún|LTranslit=xiàncún
@@ -5792,6 +5986,7 @@
 13	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s195
+# parallel_id = zhgsd/dev195
 # text = 由新加坡著名电视演员郑惠玉（饰演洛其芳）和李南星（饰演言飞）担纲主演。
 # translit = yóuxīnjiāpōzhemíngdiànshìyǎnyuánzhèng惠yù(shìyǎnluòqí芳)hélinánxīng(shìyǎnyánfēi)dāngāngzhǔyǎn.
 1	由	由	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=yóu|LTranslit=yóu
@@ -5819,6 +6014,7 @@
 23	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s196
+# parallel_id = zhgsd/dev196
 # text = 身体细长而扁平，白色或黄色，没有眼睛，尾部具有一对尾须或尾铗，触角长，如念珠状。
 # translit = shēntǐxìzhǎng'érbiǎnpíng,báisèhuòhuángsè,méiyǒuyǎnjing,wěibùjùyǒuyīduìwěixūhuòwěi铗,chùjiǎozhǎng,rúniànzhūzhuàng.
 1	身体	身体	NOUN	NN	_	6	nsubj	_	SpaceAfter=No|Translit=shēntǐ|LTranslit=shēntǐ
@@ -5850,6 +6046,7 @@
 27	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s197
+# parallel_id = zhgsd/dev197
 # text = 东邻湘潭、衡山，南接衡阳，西毗邵东、涟源，北界娄底、湘乡。
 # translit = dōnglín湘tán,héngshān,nánjiēhéngyáng,xi毗邵dōng,涟yuán,běijiè娄dǐ,湘xiāng.
 1	东邻	东邻	VERB	VV	_	14	advcl	_	SpaceAfter=No|Translit=dōnglín|LTranslit=dōnglín
@@ -5872,6 +6069,7 @@
 18	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s198
+# parallel_id = zhgsd/dev198
 # text = 而驯养的双峰驼是无法喝咸水的。
 # translit = 'ér驯yǎngdeshuāngfēngtuoshìwúfǎhēxiánshuǐde.
 1	而	而	SCONJ	RB	_	5	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -5886,6 +6084,7 @@
 10	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s199
+# parallel_id = zhgsd/dev199
 # text = 双峰驼因其耐寒，耐旱和对高海拔地区的适应力而于中亚长期驯养作驮畜，例如丝绸之路的骆驼商队。
 # translit = shuāngfēngtuoyīnqínàihán,nàihànhéduìgāohǎibádeqūdeshìyīnglì'éryúzhōngyàzhǎngqī驯yǎngzuòtuóchù,lìrúsīchóuzhīlùdeluòtuoshāngduì.
 1	双峰驼	双峰驼	NOUN	NN	_	21	nsubj	_	SpaceAfter=No|Translit=shuāngfēngtuo|LTranslit=shuāngfēngtuo
@@ -5921,6 +6120,7 @@
 31	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s200
+# parallel_id = zhgsd/dev200
 # text = 所以罗式几何中的一些几何事实没有像欧式几何那样容易被接受。
 # translit = suǒyǐluōshìjǐhézhōngdeyīxiējǐhéshìshíméiyǒuxiàng'ōushìjǐhénàyàngróngyìbèijiēshòu.
 1	所以	所以	SCONJ	RB	_	10	mark	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -5944,6 +6144,7 @@
 19	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s201
+# parallel_id = zhgsd/dev201
 # text = 实际上的双筒望远镜当然多少有些误差。
 # translit = shíjìshàngdeshuāngtǒngwàngyuǎnjìngdāngránduōshǎoyǒuxiēwùchà.
 1	实际	实际	NOUN	NN	_	7	nmod	_	SpaceAfter=No|Translit=shíjì|LTranslit=shíjì
@@ -5960,6 +6161,7 @@
 12	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s202
+# parallel_id = zhgsd/dev202
 # text = 然而，更多的“盖梯尔式”的反例被制造出来，使得附加了各种额外要求的JTB理论仍然无法准确地描述“知道”这个概念。
 # translit = rán'ér,gèngduōde“gàitī'ěrshì”defǎnlìbèizhìzàochūlái,shǐdefùjiālegèzhǒng'éwàiyàoqiúdeJTBlǐlùnréngránwúfǎzhǔnquèdemiáoshù“zhīdào”zhègègàiniàn.
 1	然而	然而	SCONJ	RB	_	15	mark	_	SpaceAfter=No|Translit=rán'ér|LTranslit=rán'ér
@@ -5999,6 +6201,7 @@
 35	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s203
+# parallel_id = zhgsd/dev203
 # text = 当证明这样的数学猜想遇到困难时，数学家会趋向于寻找一个反例，以说明这个猜想是错误的。
 # translit = dāngzhèngmíngzhèyàngdeshùxuécāixiǎngyùdàokùnnánshí,shùxuéjiāhuìqūxiàngyúxúnzhǎoyīgèfǎnlì,yǐshuōmíngzhègècāixiǎngshìcuòwùde.
 1	当	当	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=dāng|LTranslit=dāng
@@ -6032,6 +6235,7 @@
 29	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s204
+# parallel_id = zhgsd/dev204
 # text = 于是罗马的异端裁判所成立，由罗马教廷控制。
 # translit = yúshìluōmǎdeyìduāncáipànsuǒchénglì,yóuluōmǎjiàotíngkòngzhì.
 1	于是	于是	SCONJ	RB	_	9	mark	_	SpaceAfter=No|Translit=yúshì|LTranslit=yúshì
@@ -6049,6 +6253,7 @@
 13	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s205
+# parallel_id = zhgsd/dev205
 # text = 异端裁判所的正式名称为“最高宗教法庭”，其目的在于抑制异端的兴起，防止教会的分裂。
 # translit = yìduāncáipànsuǒdezhèngshìmíngchēngwèi“zuìgāozōngjiàofǎtíng”,qímùdezàiyúyìzhìyìduāndexìngqǐ,fángzhǐjiàohuìdefēnliè.
 1	异端	异端	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=yìduān|LTranslit=yìduān
@@ -6080,6 +6285,7 @@
 27	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s206
+# parallel_id = zhgsd/dev206
 # text = 但这个联盟在1797年因联军被拿破仑所率领的法国意大利方面军打败，最后两方议和，联盟瓦解。
 # translit = dànzhègèliánméngzài1797niányīnliánjūnbèinápò仑suǒlǜlǐngdefǎguóyìdàlìfāngmiànjūndǎbài,zuìhòuliǎngfāngyìhé,liánméngwǎjiě.
 1	但	但	SCONJ	RB	_	4	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -6112,6 +6318,7 @@
 28	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s207
+# parallel_id = zhgsd/dev207
 # text = 所以，有关成年人及老年人心理发展的研究开始如雨后春笋的发表。
 # translit = suǒyǐ,yǒuguānchéngniánrénjílǎoniánrénxīnlǐfāzhǎndeyánjiūkāishǐrúyǔhòuchūn笋defābiǎo.
 1	所以	所以	SCONJ	RB	_	13	mark	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -6134,6 +6341,7 @@
 18	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s208
+# parallel_id = zhgsd/dev208
 # text = 渔业和工业也有重要的地位。
 # translit = yúyèhégōngyèyěyǒuzhòngyàodedewèi.
 1	渔业	渔业	NOUN	NN	_	5	nsubj	_	SpaceAfter=No|Translit=yúyè|LTranslit=yúyè
@@ -6147,6 +6355,7 @@
 9	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s209
+# parallel_id = zhgsd/dev209
 # text = 世界上，只有日本宣布实行免费的中等教育及高等教育。
 # translit = shìjièshàng,zhǐyǒurìběnxuānbùshíxíngmiǎnfèidezhōngděngjiàoyùjígāoděngjiàoyù.
 1	世界	世界	NOUN	NN	_	4	obl	_	SpaceAfter=No|Translit=shìjiè|LTranslit=shìjiè
@@ -6166,6 +6375,7 @@
 15	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s210
+# parallel_id = zhgsd/dev210
 # text = 十九世纪的自由思想家们指出，在教育范畴内的过多的国家干预是有危险的，这些危险体现在依靠国家干预来削弱教会的控制以及从家长手中夺回对其子女的教育权。
 # translit = shíjiǔshìjìdezìyóusīxiǎngjiāmenzhǐchū,zàijiàoyùfàn畴nèideguòduōdeguójiāgànyùshìyǒuwēixiǎnde,zhèxiēwēixiǎntǐxiànzàiyīkàoguójiāgànyùláixuēruòjiàohuìdekòngzhìyǐjícóngjiāzhǎngshǒuzhōngduóhuíduìqízinǚdejiàoyùquán.
 1	十九	十九	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=shíjiǔ|LTranslit=shíjiǔ
@@ -6217,6 +6427,7 @@
 47	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s211
+# parallel_id = zhgsd/dev211
 # text = 按照传统，家长承担着对其子女进行教育的责任，然而考虑到教育系统的风险，家长在这其中的角色被削弱了。
 # translit = 'ànzhàochuántǒng,jiāzhǎngchéngdānzheduìqízinǚjìnxíngjiàoyùdezérèn,rán'érkǎolǜdàojiàoyùxìtǒngdefēngxiǎn,jiāzhǎngzàizhèqízhōngdejiǎosèbèixuēruòle.
 1	按照	按照	ADP	IN	_	2	case	_	SpaceAfter=No|Translit='ànzhào|LTranslit='ànzhào
@@ -6253,6 +6464,7 @@
 32	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s212
+# parallel_id = zhgsd/dev212
 # text = 在指令式编程语言中，同样的行为用常量来表达，它和通常的变数存在反差。
 # translit = zàizhǐlìngshìbiānchéngyǔyánzhōng,tóngyàngdexíngwèiyòngchángliàngláibiǎodá,tāhétōngchángdebiànshùcúnzàifǎnchà.
 1	在	在	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -6280,6 +6492,7 @@
 23	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s213
+# parallel_id = zhgsd/dev213
 # text = 5月26日，叙利亚自由军在107处作战。
 # translit = 5yuè26rì,xùlìyàzìyóujūnzài107chùzuòzhàn.
 1	5	5	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=5|LTranslit=5
@@ -6297,6 +6510,7 @@
 13	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s214
+# parallel_id = zhgsd/dev214
 # text = 婴儿和儿童的发育遵循一定的规律。
 # translit = yīngrhértóngdefāyùzūnxúnyīdìngdeguīlǜ.
 1	婴儿	婴儿	NOUN	NN	_	5	nmod	_	SpaceAfter=No|Translit=yīngr|LTranslit=yīngr
@@ -6311,6 +6525,7 @@
 10	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s215
+# parallel_id = zhgsd/dev215
 # text = 顾名思义，发育性口吃是一种发育性的疾病。
 # translit = gùmíngsīyì,fāyùxìngkǒuchīshìyīzhǒngfāyùxìngdejíbìng.
 1	顾名思义	顾名思义	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=gùmíngsīyì|LTranslit=gùmíngsīyì
@@ -6328,6 +6543,7 @@
 13	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s216
+# parallel_id = zhgsd/dev216
 # text = 10月15日，解放军渡海发动厦门战役，先佯攻鼓浪屿，成功吸引国军注意力，造成国军判断失误。
 # translit = 10yuè15rì,jiěfàngjūndùhǎifādòngshàménzhànyì,xiān佯gōnggǔlàngyǔ,chénggōngxīyǐnguójūnzhùyìlì,zàochéngguójūnpànduànshīwù.
 1	10	10	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=10|LTranslit=10
@@ -6360,6 +6576,7 @@
 28	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s217
+# parallel_id = zhgsd/dev217
 # text = 1949年6月以前，国军根本未在金门岛上设防。
 # translit = 1949nián6yuèyǐqián,guójūngēnběnwèizàijīnméndǎoshàngshèfáng.
 1	1949	1949	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1949|LTranslit=1949
@@ -6379,6 +6596,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s218
+# parallel_id = zhgsd/dev218
 # text = 到6月中旬，国军厦门要塞司令部才成立金门要塞总台，这才开始构筑岛上工事，铺设通信线路。
 # translit = dào6yuèzhōngxún,guójūnshàményàosāisīlìngbùcáichénglìjīnményàosāizǒngtái,zhècáikāishǐgòuzhùdǎoshànggōngshì,pùshètōngxìnxiànlù.
 1	到	到	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=dào|LTranslit=dào
@@ -6410,6 +6628,7 @@
 27	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s219
+# parallel_id = zhgsd/dev219
 # text = 解放军迅速夺取了闽北、闽南，但缺乏海战经验，且无海、空军掩护作战。
 # translit = jiěfàngjūnxùnsùduóqǔle闽běi,闽nán,dànquēfáhǎizhànjīngyàn,qiěwúhǎi,kōngjūnyǎnhùzuòzhàn.
 1	解放	解放	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=jiěfàng|LTranslit=jiěfàng
@@ -6436,6 +6655,7 @@
 22	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s220
+# parallel_id = zhgsd/dev220
 # text = 古巨基于2006年度得到四台联颁音乐大奖歌曲大奖成为继陈慧琳之后连续夺得最多次歌曲奖的歌手。
 # translit = gǔjùjīyú2006niándùdedàosìtáiliánbānyīnlèdàjiǎnggēqūdàjiǎngchéngwèijìchénhuì琳zhīhòuliánxùduódezuìduōcìgēqūjiǎngdegēshǒu.
 1	古	古	PROPN	NNP	_	14	nsubj	_	SpaceAfter=No|Translit=gǔ|LTranslit=gǔ
@@ -6468,6 +6688,7 @@
 28	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s221
+# parallel_id = zhgsd/dev221
 # text = 亚历山大先后在格拉尼库斯河和伊苏斯击败波斯军队，从波斯人手中夺取了叙利亚和埃及。
 # translit = yàlìshāndàxiānhòuzàigélāníkùsīhéhéyīsūsījībàibōsījūnduì,cóngbōsīrénshǒuzhōngduóqǔlexùlìyàhé'āijí.
 1	亚历山大	亚历山大	PROPN	NNP	_	16	nsubj	_	SpaceAfter=No|Translit=yàlìshāndà|LTranslit=yàlìshāndà
@@ -6493,6 +6714,7 @@
 21	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s222
+# parallel_id = zhgsd/dev222
 # text = 值得一提的是，当时的夫妻年龄结构也大约是这样的组成模式，即30岁左右的丈夫与10几岁妻子的组合。
 # translit = zhídeyītídeshì,dāngshídefuqīniánlíngjiégòuyědàyuēshìzhèyàngdezǔchéngmóshì,jí30suìzuǒyòudezhàngfuyǔ10jǐsuìqīzidezǔhé.
 1	值得	值得	VERB	VV	_	4	csubj	_	SpaceAfter=No|Translit=zhíde|LTranslit=zhíde
@@ -6528,6 +6750,7 @@
 31	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s223
+# parallel_id = zhgsd/dev223
 # text = 因为对平民阶级的男子而言，贵族的那套追求方法太不切实际，而男妓的存在则可以满足他们对少年的爱慕。
 # translit = yīnwèiduìpíngmínjiējídenánzi'éryán,guìzúdenàtàozhuīqiúfāngfǎtàibùqièshíjì,'érnán妓decúnzàizékěyǐmǎnzútāmenduìshǎoniánde'àimù.
 1	因为	因为	ADP	IN	_	17	case	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -6563,6 +6786,7 @@
 31	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s224
+# parallel_id = zhgsd/dev224
 # text = 公元前7世纪，古希腊社会进一步发展，古希腊艺术也随之进步。
 # translit = gōngyuánqián7shìjì,gǔxī腊shèhuìjìnyībùfāzhǎn,gǔxī腊yìshùyěsuízhījìnbù.
 1	公元	公元	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=gōngyuán|LTranslit=gōngyuán
@@ -6588,6 +6812,7 @@
 21	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s225
+# parallel_id = zhgsd/dev225
 # text = 他补充道，当时斯巴达人还满足了他的好奇心，向他展示了位于狄俄尼索斯神庙附近、她接客时使用的房屋。
 # translit = tābǔchōngdào,dāngshísībadárénháimǎnzúletādehǎoqíxīn,xiàngtāzhǎnshìlewèiyú狄'énísuǒsīshénmiàofùjìn,tājiēkèshíshǐyòngdefángwū.
 1	他	他	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -6624,6 +6849,7 @@
 32	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s226
+# parallel_id = zhgsd/dev226
 # text = 他会用极细的线条编织出物象的表面和体块，以线条的疏密来表现物体的明暗。
 # translit = tāhuìyòngjíxìdexiàntiáobiānzhīchūwùxiàngdebiǎomiànhétǐkuài,yǐxiàntiáodeshūmìláibiǎoxiànwùtǐdemíng'àn.
 1	他	他	PRON	PRP	Person=3	15	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -6652,6 +6878,7 @@
 24	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s227
+# parallel_id = zhgsd/dev227
 # text = 其作品也成为音乐会上常见的曲目，在欧洲甚至产生了过热的现象。
 # translit = qízuòpǐnyěchéngwèiyīnlèhuìshàngchángjiàndeqūmù,zài'ōuzhōushénzhìchǎnshēngleguòrèdexiànxiàng.
 1	其	其	PRON	PRP	Person=3	2	nmod	_	SpaceAfter=No|Translit=qí|LTranslit=qí
@@ -6677,6 +6904,7 @@
 21	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s228
+# parallel_id = zhgsd/dev228
 # text = 自1960年起，马勒成为了最常被录音的作曲家之一，多位指挥家录制其交响曲全集。
 # translit = zì1960niánqǐ,mǎlēichéngwèilezuìchángbèilùyīndezuòqūjiāzhīyī,duōwèizhǐhuījiālùzhìqíjiāoxiǎngqūquánjí.
 1	自	自	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zì|LTranslit=zì
@@ -6709,6 +6937,7 @@
 28	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s229
+# parallel_id = zhgsd/dev229
 # text = 全镇辖域总面积154.2平方公里，总人口35,190人（2000年人口普查），下辖10个行政村、3个社区。
 # translit = quánzhènxiáyùzǒngmiànjī154.2píngfānggōnglǐ,zǒngrénkǒu35,190rén(2000niánrénkǒupǔchá),xiàxiá10gèxíngzhèngcūn,3gèshèqū.
 1	全镇	全镇	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=quánzhèn|LTranslit=quánzhèn
@@ -6741,6 +6970,7 @@
 28	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s230
+# parallel_id = zhgsd/dev230
 # text = 他幼年受过良好的教育，通晓拉丁语和希腊语，能诵荷马史诗原文，并到雅典学过哲学。
 # translit = tāyòuniánshòuguòliánghǎodejiàoyù,tōngxiǎolādīngyǔhéxī腊yǔ,néngsònghémǎshǐshīyuánwén,bìngdào雅diǎnxuéguòzhéxué.
 1	他	他	PRON	PRP	Person=3	25	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -6773,6 +7003,7 @@
 28	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s231
+# parallel_id = zhgsd/dev231
 # text = 全诗计12卷，长达近万行，是遵照奥古斯都的旨意创作出来的。
 # translit = quánshījì12juǎn,zhǎngdájìnwànxíng,shìzūnzhào'àogǔsīdōude旨yìchuàngzuòchūláide.
 1	全诗	全诗	NOUN	NN	_	11	nsubj	_	SpaceAfter=No|Translit=quánshī|LTranslit=quánshī
@@ -6796,6 +7027,7 @@
 19	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s232
+# parallel_id = zhgsd/dev232
 # text = 其散文语言简洁凝练，朴实无华，体现了和西塞罗迥异的风格。
 # translit = qísànwényǔyánjiǎnjiéníngliàn,pǔshíwúhuá,tǐxiànlehéxisāiluō迥yìdefēnggé.
 1	其	其	PRON	PRP	Person=3	3	nmod	_	SpaceAfter=No|Translit=qí|LTranslit=qí
@@ -6816,6 +7048,7 @@
 16	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s233
+# parallel_id = zhgsd/dev233
 # text = 卢克莱修（前99年-前55年）生于共和国末期，唯一的传世之作《物性论》（一译《论自然》）共六卷，每卷千余行，是一部哲理诗。
 # translit = 卢kè莱xiū(qián99nián-qián55nián)shēngyúgònghéguómòqī,wéiyīdechuánshìzhīzuò«wùxìnglùn»(yīyì«lùnzìrán»)gòngliùjuǎn,měijuǎnqiānyúxíng,shìyībùzhélǐshī.
 1	卢克莱修	卢克莱修	PROPN	NNP	_	11	nsubj	_	SpaceAfter=No|Translit=卢kè莱xiū|LTranslit=卢kè莱xiū
@@ -6867,6 +7100,7 @@
 47	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s234
+# parallel_id = zhgsd/dev234
 # text = 维吉尔在创作《埃涅阿斯纪》的时候虽有意摹仿荷马史诗，但全诗强调使命感、责任感，洋溢着严肃、哀婉和悲天悯人的情调，是典型的罗马风格。
 # translit = wéijí'ěrzàichuàngzuò«'āi涅'āsījì»deshíhousuīyǒuyì摹fǎnghémǎshǐshī,dànquánshīqiángdiàoshǐmìnggǎn,zérèngǎn,yáng溢zheyánsù,'āi婉hébēitiān悯réndeqíngdiào,shìdiǎnxíngdeluōmǎfēnggé.
 1	维吉尔	维吉尔	PROPN	NNP	_	11	nsubj	_	SpaceAfter=No|Translit=wéijí'ěr|LTranslit=wéijí'ěr
@@ -6911,6 +7145,7 @@
 40	。	。	PUNCT	.	_	39	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s235
+# parallel_id = zhgsd/dev235
 # text = 水库正常库容为1202万立方米，集雨面积为46平方千米，海拔为26.5米。
 # translit = shuǐkùzhèngchángkùróngwèi1202wànlìfāngmǐ,jíyǔmiànjīwèi46píngfāngqiānmǐ,hǎibáwèi26.5mǐ.
 1	水库	水库	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=shuǐkù|LTranslit=shuǐkù
@@ -6933,6 +7168,7 @@
 18	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s236
+# parallel_id = zhgsd/dev236
 # text = 这样，就可根据词语的词性和词语的组合规律（如语法关系）等来断句。
 # translit = zhèyàng,jiùkěgēnjùcíyǔdecíxìnghécíyǔdezǔhéguīlǜ(rúyǔfǎguānxì)děngláiduànjù.
 1	这样	这样	ADV	RB	_	21	advmod	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
@@ -6959,6 +7195,7 @@
 22	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s237
+# parallel_id = zhgsd/dev237
 # text = 此外，其他废弃物、废水、废气等都不会排放。
 # translit = cǐwài,qítāfèiqìwù,fèishuǐ,fèiqìděngdōubùhuìpáifàng.
 1	此外	此外	NOUN	NN	_	13	obl	_	SpaceAfter=No|Translit=cǐwài|LTranslit=cǐwài
@@ -6977,6 +7214,7 @@
 14	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s238
+# parallel_id = zhgsd/dev238
 # text = 但是，大型水力发电系统有几个显著的社会的和环境的缺点：在规划水库区中生活的人民颠沛流离，在施工期间和水库洪水期释放大量的二氧化碳和甲烷，破坏水生的生态系统和鸟类。
 # translit = dànshì,dàxíngshuǐlìfādiànxìtǒngyǒujǐgèxiǎnzhedeshèhuìdehéhuánjìngdequēdiǎn:zàiguīhuàshuǐkùqūzhōngshēnghuóderénmíndiānpèiliúlí,zàishīgōngqījiānhéshuǐkùhóngshuǐqīshìfàngdàliàngde'èryǎnghuàtànhéjiǎ烷,pòhuàishuǐshēngdeshēngtàixìtǒnghéniǎolèi.
 1	但是	但是	SCONJ	RB	_	7	mark	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -7031,6 +7269,7 @@
 50	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s239
+# parallel_id = zhgsd/dev239
 # text = 其次，尽管化石燃料技术是比较成熟的，可再生能源技术正在迅速被改进。
 # translit = qícì,jǐnguǎnhuàshíránliàojìshùshìbǐjiàochéngshúde,kězàishēngnéngyuánjìshùzhèngzàixùnsùbèigǎijìn.
 1	其次	其次	NOUN	NN	_	20	obl	_	SpaceAfter=No|Translit=qícì|LTranslit=qícì
@@ -7056,6 +7295,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s240
+# parallel_id = zhgsd/dev240
 # text = 根据国际能源署（IEA）的一个在2011年的预测，在50年之内，太阳能发电站可能会产生世界上大部分电力，显著减少对环境有害的温室气体的排放。
 # translit = gēnjùguójìnéngyuánshǔ(IEA)deyīgèzài2011niándeyùcè,zài50niánzhīnèi,tàiyángnéngfādiànzhànkěnénghuìchǎnshēngshìjièshàngdàbùfēndiànlì,xiǎnzhejiǎnshǎoduìhuánjìngyǒuhàidewēnshìqìtǐdepáifàng.
 1	根据	根据	ADP	IN	_	15	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -7105,6 +7345,7 @@
 45	。	。	PUNCT	.	_	36	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s241
+# parallel_id = zhgsd/dev241
 # text = 问世之初可口可乐的主要成分主要有两种，分别是古柯碱及咖啡因。
 # translit = wènshìzhīchūkěkǒukělèdezhǔyàochéngfēnzhǔyàoyǒuliǎngzhǒng,fēnbiéshìgǔ柯jiǎnjíkāfēiyīn.
 1	问世	问世	VERB	VV	_	8	advcl	_	SpaceAfter=No|Translit=wènshì|LTranslit=wènshì
@@ -7126,6 +7367,7 @@
 17	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s242
+# parallel_id = zhgsd/dev242
 # text = 此译名被普遍认为是最经典的译名之一。
 # translit = cǐyìmíngbèipǔbiànrènwèishìzuìjīngdiǎndeyìmíngzhīyī.
 1	此	此	DET	DT	_	2	det	_	SpaceAfter=No|Translit=cǐ|LTranslit=cǐ
@@ -7143,6 +7385,7 @@
 13	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s243
+# parallel_id = zhgsd/dev243
 # text = 快乐之道提倡真实是相对的，这些相对哲学现今被称为诡辩，早在二千多年前已被苏格拉底和他的弟子否定。
 # translit = kuàilèzhīdàotíchàngzhēnshíshìxiāngduìde,zhèxiēxiāngduìzhéxuéxiànjīnbèichēngwèiguǐbiàn,zǎozài'èrqiānduōniánqiányǐbèisūgélādǐhétādedìzifǒudìng.
 1	快乐	快乐	ADJ	JJ	_	3	amod	_	SpaceAfter=No|Translit=kuàilè|LTranslit=kuàilè
@@ -7179,6 +7422,7 @@
 32	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s244
+# parallel_id = zhgsd/dev244
 # text = 目前接驳车的营运业务则是由大南汽车负责。
 # translit = mùqiánjiēbóchēdeyíngyùnyèwuzéshìyóudànánqìchēfùzé.
 1	目前	目前	NOUN	NN	_	8	nmod:tmod	_	SpaceAfter=No|Translit=mùqián|LTranslit=mùqián
@@ -7195,6 +7439,7 @@
 12	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s245
+# parallel_id = zhgsd/dev245
 # text = 1973年7月10日，为了要推展体育用品的外销市场，以贸易商、体育用品批发商、体育用品制造商为基础的台北市体育用品商业同业公会应运而生，胡益兰成为第一任理事长，李荣淮成为常务理事长，并且开始针对各国体育用品发展之情况进行调查。
 # translit = 1973nián7yuè10rì,wèileyàotuīzhǎntǐyùyòngpǐndewàixiāoshìchǎng,yǐmàoyìshāng,tǐyùyòngpǐnpīfāshāng,tǐyùyòngpǐnzhìzàoshāngwèijīchǔdetáiběishìtǐyùyòngpǐnshāngyètóngyègōnghuìyīngyùn'érshēng,húyìlánchéngwèidìyīrènlǐshìzhǎng,liróng淮chéngwèichángwulǐshìzhǎng,bìngqiěkāishǐzhēnduìgèguótǐyùyòngpǐnfāzhǎnzhīqíngkuàngjìnxíngdiàochá.
 1	1973	1973	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1973|LTranslit=1973
@@ -7269,6 +7514,7 @@
 70	。	。	PUNCT	.	_	40	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s246
+# parallel_id = zhgsd/dev246
 # text = 1976年，张建邦博士出任董事长。
 # translit = 1976nián,zhāngjiànbāngbóshìchūrèn董shìzhǎng.
 1	1976	1976	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1976|LTranslit=1976
@@ -7283,6 +7529,7 @@
 10	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s247
+# parallel_id = zhgsd/dev247
 # text = 黄岩路桥机场建于1987年，是全国第一个县级民航站，2001年1月起，台州市替代黄岩区接管该机场，同时加挂台州市民航局牌子。
 # translit = huángyánlùqiáojīchǎngjiànyú1987nián,shìquánguódìyīgèxiànjímínhángzhàn,2001nián1yuèqǐ,táizhōushìtìdàihuángyánqūjiēguǎngāijīchǎng,tóngshíjiāguàtáizhōushìmínhángjúpáizi.
 1	黄岩	黄岩	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=huángyán|LTranslit=huángyán
@@ -7326,6 +7573,7 @@
 39	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s248
+# parallel_id = zhgsd/dev248
 # text = 前台湾国防部长李杰在军购案回答李敖质询时，表示在大陆全力攻台下，台湾只有防守两个星期的能力。
 # translit = qiántáiwānguófángbùzhǎnglijiézàijūngòu'ànhuídáli敖zhìxúnshí,biǎoshìzàidàlùquánlìgōngtáixià,táiwānzhǐyǒufángshǒuliǎnggèxīngqīdenénglì.
 1	前	前	DET	DT	_	4	det	_	SpaceAfter=No|Translit=qián|LTranslit=qián
@@ -7362,6 +7610,7 @@
 32	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s249
+# parallel_id = zhgsd/dev249
 # text = 新闻自由在台湾常被利用于爆料与不负责任的言论上，而非理性的讨论。
 # translit = xīnwénzìyóuzàitáiwānchángbèilìyòngyúbàoliàoyǔbùfùzérèndeyánlùnshàng,'érfēilǐxìngdetǎolùn.
 1	新闻	新闻	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=xīnwén|LTranslit=xīnwén
@@ -7388,6 +7637,7 @@
 22	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s250
+# parallel_id = zhgsd/dev250
 # text = 这些显然都是台湾媒体所需大力加强的。
 # translit = zhèxiēxiǎnrándōushìtáiwānméitǐsuǒxūdàlìjiāqiángde.
 1	这些	这些	PRON	PRD	_	3	nsubj	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -7403,6 +7653,7 @@
 11	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s251
+# parallel_id = zhgsd/dev251
 # text = 另一方面，民营报纸亦于艰难中求生，1946年创刊于台中的《民声日报》当时办的有声有色，但最后由《联合报》及《征信新闻》脱颖而出。
 # translit = lìngyīfāngmiàn,mínyíngbàozhǐyìyújiānnánzhōngqiúshēng,1946niánchuàngkānyútáizhōngde«mínshēngrìbào»dāngshíbàndeyǒushēngyǒusè,dànzuìhòuyóu«liánhébào»jí«zhēngxìnxīnwén»tuōyǐng'érchū.
 1	另	另	DET	DT	_	3	det	_	SpaceAfter=No|Translit=lìng|LTranslit=lìng
@@ -7448,6 +7699,7 @@
 41	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s252
+# parallel_id = zhgsd/dev252
 # text = 北方全真教偏重自行主义，重视修养苦行，南方偏重他力主义，重视符咒科仪，一般来说，台湾的道教来自南方福建泉州与漳州一代所盛行的天师教（天师道）。
 # translit = běifāngquánzhēnjiàopiānzhòngzìxíngzhǔyì,zhòngshìxiūyǎngkǔxíng,nánfāngpiānzhòngtālìzhǔyì,zhòngshìfúzhòukēyí,yībānláishuō,táiwāndedàojiàoláizìnánfāngfújiànquánzhōuyǔ漳zhōuyīdàisuǒshèngxíngdetiānshījiào(tiānshīdào).
 1	北方	北方	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=běifāng|LTranslit=běifāng
@@ -7498,6 +7750,7 @@
 46	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s253
+# parallel_id = zhgsd/dev253
 # text = 福利制度的完善已初见端倪。
 # translit = fúlìzhìdùdewánshànyǐchūjiànduān倪.
 1	福利	福利	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=fúlì|LTranslit=fúlì
@@ -7510,6 +7763,7 @@
 8	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s254
+# parallel_id = zhgsd/dev254
 # text = 在这些事件中，有11件发生在1911年的辛亥革命之后，并且有4件是受到辛亥革命的刺激而发动的。
 # translit = zàizhèxiēshìjiànzhōng,yǒu11jiànfāshēngzài1911niándexīn亥gémìngzhīhòu,bìngqiěyǒu4jiànshìshòudàoxīn亥gémìngdecìjī'érfādòngde.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -7545,6 +7799,7 @@
 31	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s255
+# parallel_id = zhgsd/dev255
 # text = 这个转变，可能和义勇军开赴内地推翻清朝，以及原本领导游击战的前台湾民主国军务大臣李秉瑞殉职有关。
 # translit = zhègèzhuǎnbiàn,kěnénghéyìyǒngjūnkāifùnèidetuīfānqīngcháo,yǐjíyuánběnlǐngdǎoyóujīzhàndeqiántáiwānmínzhǔguójūnwudàchénli秉ruì殉zhíyǒuguān.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -7579,6 +7834,7 @@
 30	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s256
+# parallel_id = zhgsd/dev256
 # text = 电影主要呈现写实风格，其题材贴近现实社会，回顾民众的真实生活，由于形式新颖、风格独特，促成了台湾电影的新风貌。
 # translit = diànyǐngzhǔyàochéngxiànxiěshífēnggé,qítícáitiējìnxiànshíshèhuì,huígùmínzhòngdezhēnshíshēnghuó,yóuyúxíngshìxīnyǐng,fēnggédútè,cùchéngletáiwāndiànyǐngdexīnfēngmào.
 1	电影	电影	NOUN	NN	_	3	nsubj	_	SpaceAfter=No|Translit=diànyǐng|LTranslit=diànyǐng
@@ -7616,6 +7872,7 @@
 33	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s257
+# parallel_id = zhgsd/dev257
 # text = 10月25日陈仪代表同盟国的中华民国政府接管台湾，接受日本帝国台湾总督兼台湾军司令官安藤利吉的投降。
 # translit = 10yuè25rìchényídàibiǎotóngméngguódezhōnghuámínguózhèngfǔjiēguǎntáiwān,jiēshòurìběndìguótáiwānzǒngdūjiāntáiwānjūnsīlìngguān'ānténglìjídetóujiàng.
 1	10	10	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=10|LTranslit=10
@@ -7651,6 +7908,7 @@
 31	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s258
+# parallel_id = zhgsd/dev258
 # text = 1945年8月14日，日本天皇发表终战诏书，二战结束。
 # translit = 1945nián8yuè14rì,rìběntiānhuángfābiǎozhōngzhàn诏shū,'èrzhànjiéshù.
 1	1945	1945	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1945|LTranslit=1945
@@ -7671,6 +7929,7 @@
 16	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s259
+# parallel_id = zhgsd/dev259
 # text = 树的稀有与其缓慢的生长速度意味着合法的供应非常稀少。
 # translit = shùdexīyǒuyǔqíhuǎnmàndeshēngzhǎngsùdùyìwèizhehéfǎdegōngyīngfēichángxīshǎo.
 1	树	树	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=shù|LTranslit=shù
@@ -7692,6 +7951,7 @@
 17	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s260
+# parallel_id = zhgsd/dev260
 # text = 第二条，台湾独立不是因为台湾人四百年来受到外来政权的压迫。
 # translit = dì'èrtiáo,táiwāndúlìbùshìyīnwèitáiwānrénsìbǎiniánláishòudàowàiláizhèngquándeyāpò.
 1	第二	第二	NUM	CD	NumType=Ord	2	nummod	_	SpaceAfter=No|Translit=dì'èr|LTranslit=dì'èr
@@ -7714,6 +7974,7 @@
 18	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s261
+# parallel_id = zhgsd/dev261
 # text = 二次大战刚结束时，台湾糖业铁路年久失修，且有钢轨轻重不一、蒸汽机车大多逾龄等问题。
 # translit = 'èrcìdàzhàngāngjiéshùshí,táiwāntángyètiělùniánjiǔshīxiū,qiěyǒugāngguǐqīngzhòngbùyī,zhēngqìjīchēdàduō逾língděngwèntí.
 1	二	二	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit='èr|LTranslit='èr
@@ -7743,6 +8004,7 @@
 25	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s262
+# parallel_id = zhgsd/dev262
 # text = 主持人也会视情形开放现场观众参赛，获胜者同样也有丰盛的奖品或丰厚的奖金。
 # translit = zhǔchírényěhuìshìqíngxíngkāifàngxiànchǎngguānzhòngcānsài,huòshèngzhětóngyàngyěyǒufēngshèngdejiǎngpǐnhuòfēnghòudejiǎngjīn.
 1	主持	主持	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=zhǔchí|LTranslit=zhǔchí
@@ -7771,6 +8033,7 @@
 24	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s263
+# parallel_id = zhgsd/dev263
 # text = 该单元曾经也出现特别版，夹到者的最高奖品为洋房一栋。
 # translit = gāidānyuáncéngjīngyěchūxiàntèbiébǎn,jiādàozhědezuìgāojiǎngpǐnwèiyángfángyī栋.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -7793,6 +8056,7 @@
 18	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s264
+# parallel_id = zhgsd/dev264
 # text = 1956年2月28日在日本东京成立的海外台独组织“台湾共和国临时政府”，其领导人称为“大统领”，但未获承认。
 # translit = 1956nián2yuè28rìzàirìběndōngjīngchénglìdehǎiwàitáidúzǔzhī“táiwāngònghéguólínshízhèngfǔ”,qílǐngdǎorénchēngwèi“dàtǒnglǐng”,dànwèihuòchéngrèn.
 1	1956	1956	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1956|LTranslit=1956
@@ -7834,6 +8098,7 @@
 37	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s265
+# parallel_id = zhgsd/dev265
 # text = 每集几乎有案件关系人访谈，结尾开始有高哲翰讲解。
 # translit = měijíjǐhuyǒu'ànjiànguānxìrénfǎngtán,jiéwěikāishǐyǒugāozhé翰jiǎngjiě.
 1	每集	每集	DET	DT	_	3	nsubj	_	SpaceAfter=No|Translit=měijí|LTranslit=měijí
@@ -7853,6 +8118,7 @@
 15	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s266
+# parallel_id = zhgsd/dev266
 # text = 信义乡与水里乡相同，是从1980年代左右，才开始辟垦茶园，所以也属于新兴的高山茶区。
 # translit = xìnyìxiāngyǔshuǐlǐxiāngxiāngtóng,shìcóng1980niándàizuǒyòu,cáikāishǐpìkěncháyuán,suǒyǐyěshǔyúxīnxìngdegāoshāncháqū.
 1	信义	信义	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=xìnyì|LTranslit=xìnyì
@@ -7884,6 +8150,7 @@
 27	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s267
+# parallel_id = zhgsd/dev267
 # text = 嘉义县是当前台湾生产高山茶的重要产区，种植的区域，以梅山乡、竹崎乡、番路乡及阿里山乡等四个山区乡镇为主。
 # translit = jiāyìxiànshìdāngqiántáiwānshēngchǎngāoshānchádezhòngyàochǎnqū,zhǒngzhídeqūyù,yǐméishānxiāng,zhúqíxiāng,fānlùxiāngjí'ālǐshānxiāngděngsìgèshānqūxiāngzhènwèizhǔ.
 1	嘉义	嘉义	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=jiāyì|LTranslit=jiāyì
@@ -7925,6 +8192,7 @@
 37	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s268
+# parallel_id = zhgsd/dev268
 # text = 斯坦·李还是李小龙的影迷，在自己的事业上也极大地受到李小龙电影的影响。
 # translit = sītǎn·liháishìlixiǎolóngdeyǐngmí,zàizìjǐdeshìyèshàngyějídàdeshòudàolixiǎolóngdiànyǐngdeyǐngxiǎng.
 1	斯坦	斯坦	PROPN	NNP	_	8	nsubj	_	SpaceAfter=No|Translit=sītǎn|LTranslit=sītǎn
@@ -7953,6 +8221,7 @@
 24	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s269
+# parallel_id = zhgsd/dev269
 # text = 电影《蜘蛛侠：惊奇再起》中，曾于蜘蛛人和蜥蜴人打斗的场景（学校某处图书室）中出现。
 # translit = diànyǐng«zhīzhū侠:jīngqízàiqǐ»zhōng,céngyúzhīzhūrénhé蜥蜴réndǎdòudechǎngjǐng(xuéxiàomǒuchùtúshūshì)zhōngchūxiàn.
 1	电影	电影	NOUN	NN	_	28	obl	_	SpaceAfter=No|Translit=diànyǐng|LTranslit=diànyǐng
@@ -7986,6 +8255,7 @@
 29	。	。	PUNCT	.	_	28	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s270
+# parallel_id = zhgsd/dev270
 # text = 科学家们最早的重建揭示出一个没有头的人形雕像。
 # translit = kēxuéjiāmenzuìzǎodezhòngjiànjiēshìchūyīgèméiyǒutóuderénxíngdiāoxiàng.
 1	科学	科学	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=kēxué|LTranslit=kēxué
@@ -8006,6 +8276,7 @@
 16	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s271
+# parallel_id = zhgsd/dev271
 # text = 谢拉特协助利物浦在这个赛季取得英超第2名并取得球会历史上最高的联赛分数。
 # translit = xièlātèxiézhùlìwù浦zàizhègèsàijìqǔdeyīngchāodì2míngbìngqǔdeqiúhuìlìshǐshàngzuìgāodeliánsàifēnshù.
 1	谢拉特	谢拉特	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=xièlātè|LTranslit=xièlātè
@@ -8031,6 +8302,7 @@
 21	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s272
+# parallel_id = zhgsd/dev272
 # text = 谢拉特是当今球坛最全能球员之一。
 # translit = xièlātèshìdāngjīnqiú坛zuìquánnéngqiúyuánzhīyī.
 1	谢拉特	谢拉特	PROPN	NNP	_	9	nsubj	_	SpaceAfter=No|Translit=xièlātè|LTranslit=xièlātè
@@ -8045,6 +8317,7 @@
 10	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s273
+# parallel_id = zhgsd/dev273
 # text = 招数并不复杂，却指住国人要害，颇见奇效。
 # translit = zhāoshùbìngbùfùzá,quèzhǐzhùguórényàohài,pōjiànqíxiào.
 1	招数	招数	NOUN	NN	_	12	nsubj	_	SpaceAfter=No|Translit=zhāoshù|LTranslit=zhāoshù
@@ -8063,6 +8336,7 @@
 14	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s274
+# parallel_id = zhgsd/dev274
 # text = 史旺森山脉是南极洲的山脉，位于玛丽伯德地，属于福特山脉的一部分，全长约15公里，处于桑德斯山东南面11公里，该山脉在1934年由美国探险队发现。
 # translit = shǐwàngsēnshānmàishìnánjízhōudeshānmài,wèiyúmǎlìbódéde,shǔyúfútèshānmàideyībùfēn,quánzhǎngyuē15gōnglǐ,chùyúsāngdésīshāndōngnánmiàn11gōnglǐ,gāishānmàizài1934niányóuměiguótànxiǎnduìfāxiàn.
 1	史旺森	史旺森	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=shǐwàngsēn|LTranslit=shǐwàngsēn
@@ -8113,6 +8387,7 @@
 46	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s275
+# parallel_id = zhgsd/dev275
 # text = 谢根荣请史树青等人鉴定一件伪造的金缕玉衣，史树青等专家认定为真品，估价24亿人民币。
 # translit = xiègēnróngqǐngshǐshùqīngděngrénjiàndìngyījiànwěizàodejīnlǚyùyī,shǐshùqīngděngzhuānjiārèndìngwèizhēnpǐn,gūjià24yìrénmínbì.
 1	谢	谢	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit=xiè|LTranslit=xiè
@@ -8145,6 +8420,7 @@
 28	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s276
+# parallel_id = zhgsd/dev276
 # text = 从1953年英国军方开始采用史特林冲锋枪以来，之后经过了数次的改良，并且也追加成为制式装备。
 # translit = cóng1953niányīngguójūnfāngkāishǐcǎiyòngshǐtèlínchōngfēngqiāngyǐlái,zhīhòujīngguòleshùcìdegǎiliáng,bìngqiěyězhuījiāchéngwèizhìshìzhuāngbèi.
 1	从	从	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=cóng|LTranslit=cóng
@@ -8177,6 +8453,7 @@
 28	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s277
+# parallel_id = zhgsd/dev277
 # text = 回到树林后，将神水喝下的史瑞克与驴子并没有任何改变，史瑞克嗅了嗅神水后突然向着毒蘑菇打喷嚏。
 # translit = huídàoshùlínhòu,jiāngshénshuǐhēxiàdeshǐruìkèyǔlǘzibìngméiyǒurènhégǎibiàn,shǐruìkèxiùlexiùshénshuǐhòutūránxiàngzhedúmógudǎpēn嚏.
 1	回到	回到	VERB	VV	_	13	advcl	_	SpaceAfter=No|Translit=huídào|LTranslit=huídào
@@ -8211,6 +8488,7 @@
 30	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s278
+# parallel_id = zhgsd/dev278
 # text = 国王给予两人祝福后就准备要离开这个伤心地，但王后却告诉国王自己仍然深爱着他，即使国王是一只青蛙。
 # translit = guówánggěiyǔliǎngrénzhùfúhòujiùzhǔnbèiyàolíkāizhègèshāngxīnde,dànwánghòuquègàosuguówángzìjǐréngránshēn'àizhetā,jíshǐguówángshìyīzhǐqīngwā.
 1	国王	国王	NOUN	NN	_	8	nsubj	_	SpaceAfter=No|Translit=guówáng|LTranslit=guówáng
@@ -8248,6 +8526,7 @@
 33	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s279
+# parallel_id = zhgsd/dev279
 # text = 镜头回到“很远很远的王国”，费欧娜也受到神水的影响晕了过去。
 # translit = jìngtóuhuídào“hěnyuǎnhěnyuǎndewángguó”,fèi'ōu娜yěshòudàoshénshuǐdeyǐngxiǎngyūnleguòqù.
 1	镜头	镜头	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=jìngtóu|LTranslit=jìngtóu
@@ -8271,6 +8550,7 @@
 19	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s280
+# parallel_id = zhgsd/dev280
 # text = 长靴猫以无辜的眼神请求原谅，而史瑞克和猫咪很快变成了朋友。
 # translit = zhǎngxuēmāoyǐwúgūdeyǎnshénqǐngqiúyuánliàng,'érshǐruìkèhémāo咪hěnkuàibiànchénglepéngyou.
 1	长靴	长靴	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=zhǎngxuē|LTranslit=zhǎngxuē
@@ -8293,6 +8573,7 @@
 18	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s281
+# parallel_id = zhgsd/dev281
 # text = 《西城故事》（West Side Story）是桑坦事业的突破。
 # translit = «xichénggùshì»(West Side Story)shìsāngtǎnshìyèdetūpò.
 1	《	《	PUNCT	(	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -8312,6 +8593,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s282
+# parallel_id = zhgsd/dev282
 # text = 这出音乐剧被当年时代杂志评为桑坦最优秀的成就。
 # translit = zhèchūyīnlèjùbèidāngniánshídàizázhìpíngwèisāngtǎnzuìyōuxiùdechéngjiù.
 1	这	这	DET	DT	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -8332,6 +8614,7 @@
 16	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s283
+# parallel_id = zhgsd/dev283
 # text = 他将四人强留在工厂，并从他们身上各拿走一部分来制作巧克力棒。
 # translit = tājiāngsìrénqiángliúzàigōngchǎng,bìngcóngtāmenshēnshànggènázǒuyībùfēnláizhìzuòqiǎokèlìbàng.
 1	他	他	PRON	PRP	Person=3	18	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -8357,6 +8640,7 @@
 21	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s284
+# parallel_id = zhgsd/dev284
 # text = 拉森与祖父母住在乡村小木屋里，他相当喜爱这个地方，在北瑞典冰雪纷飞的漫长冬季，他就靠越野滑雪板上下学。
 # translit = lāsēnyǔzǔfùmǔzhùzàixiāngcūnxiǎomùwūlǐ,tāxiāngdāngxǐ'àizhègèdefāng,zàiběiruìdiǎnbīngxuěfēnfēidemànzhǎngdōngjì,tājiùkàoyuèyěhuáxuěbǎnshàngxiàxué.
 1	拉森	拉森	PROPN	NNP	_	4	nsubj	_	SpaceAfter=No|Translit=lāsēn|LTranslit=lāsēn
@@ -8395,6 +8679,7 @@
 34	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s285
+# parallel_id = zhgsd/dev285
 # text = 由于《史通》总结唐以前史学的全部问题，因而拥有极高史学地位，对后世影响深远。
 # translit = yóuyú«shǐtōng»zǒngjiétángyǐqiánshǐxuédequánbùwèntí,yīn'éryōngyǒujígāoshǐxuédewèi,duìhòushìyǐngxiǎngshēnyuǎn.
 1	由于	由于	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -8422,6 +8707,7 @@
 23	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s286
+# parallel_id = zhgsd/dev286
 # text = 右龙是日本将棋的棋子之一。
 # translit = yòulóngshìrìběnjiāngqídeqízizhīyī.
 1	右龙	右龙	NOUN	NN	_	8	nsubj	_	SpaceAfter=No|Translit=yòulóng|LTranslit=yòulóng
@@ -8435,6 +8721,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s287
+# parallel_id = zhgsd/dev287
 # text = 1977年1月10日，叶企孙侄子叶铭汉交工资给叔父，发觉他病情恶化。
 # translit = 1977nián1yuè10rì,yèqǐsūn侄ziyè铭hànjiāogōngzīgěishūfù,fājuétābìngqíng'èhuà.
 1	1977	1977	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1977|LTranslit=1977
@@ -8461,6 +8748,7 @@
 22	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s288
+# parallel_id = zhgsd/dev288
 # text = 后来，他躲入一条运兵船，终于到达重庆。
 # translit = hòulái,tāduǒrùyītiáoyùnbīngchuán,zhōngyúdàodázhòngqìng.
 1	后来	后来	NOUN	NN	_	11	nmod:tmod	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -8478,6 +8766,7 @@
 13	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s289
+# parallel_id = zhgsd/dev289
 # text = 当时，他的父亲去世，母亲对他十分溺爱。
 # translit = dāngshí,tādefùqīnqùshì,mǔqīnduìtāshífēn溺'ài.
 1	当时	当时	NOUN	NN	_	6	nmod:tmod	_	SpaceAfter=No|Translit=dāngshí|LTranslit=dāngshí
@@ -8495,6 +8784,7 @@
 13	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s290
+# parallel_id = zhgsd/dev290
 # text = 1995年5月，叶小文出掌国务院宗教事务局；同年12月，作为国务院特派专员，赴西藏参与主持第十一世班禅的金瓶掣签和坐床大典。
 # translit = 1995nián5yuè,yèxiǎowénchūzhǎngguówuyuànzōngjiàoshìwujú;tóngnián12yuè,zuòwèiguówuyuàntèpàizhuānyuán,fùxicángcānyǔzhǔchídìshíyīshìbān禅dejīnpíng掣qiānhézuòchuángdàdiǎn.
 1	1995	1995	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1995|LTranslit=1995
@@ -8538,6 +8828,7 @@
 39	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s291
+# parallel_id = zhgsd/dev291
 # text = 一个月后，在漳州执行侦察任务时，因遭遇暴雨，飞机失事，叶少毅不幸牺牲。
 # translit = yīgèyuèhòu,zài漳zhōuzhíxíngzhēnchárènwushí,yīnzāoyùbàoyǔ,fēijīshīshì,yèshǎoyìbùxìngxīshēng.
 1	一	一	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -8566,6 +8857,7 @@
 24	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s292
+# parallel_id = zhgsd/dev292
 # text = 11岁的叶甫根尼·普鲁申科借居在圣彼得堡的公寓，小房间内仅有一张桌与椅子、折叠床，叶甫根尼·普鲁申科不仅要生活上学处理家务，更要面对团队中的由来已久的陋习：欺负新人。
 # translit = 11suìdeyèfugēnní·pǔlǔshēnkējièjūzàishèngbǐdebǎodegōngyù,xiǎofángjiānnèijǐnyǒuyīzhāngzhuōyǔyǐzi,zhédiéchuáng,yèfugēnní·pǔlǔshēnkēbùjǐnyàoshēnghuóshàngxuéchùlǐjiāwu,gèngyàomiànduìtuánduìzhōngdeyóuláiyǐjiǔdelòuxí:qīfùxīnrén.
 1	11	11	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=11|LTranslit=11
@@ -8621,6 +8913,7 @@
 51	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s293
+# parallel_id = zhgsd/dev293
 # text = 叶甫根尼·普鲁申科在2010年加拿大温哥华举行的冬季奥运会，于短曲项目获得90.85分，打破奥运会纪录，领先所有竞争对手。
 # translit = yèfugēnní·pǔlǔshēnkēzài2010niánjiānádàwēngēhuájǔxíngdedōngjì'àoyùnhuì,yúduǎnqūxiàngmùhuòde90.85fēn,dǎpò'àoyùnhuìjìlù,lǐngxiānsuǒyǒujìngzhēngduìshǒu.
 1	叶甫根尼	叶甫根尼	PROPN	NNP	_	27	nsubj	_	SpaceAfter=No|Translit=yèfugēnní|LTranslit=yèfugēnní
@@ -8656,6 +8949,7 @@
 31	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s294
+# parallel_id = zhgsd/dev294
 # text = 1812年7月23日，他随军前往俄国，9月14日到达莫斯科，之后，他取道柯尼斯堡撤回巴黎。
 # translit = 1812nián7yuè23rì,tāsuíjūnqiánwǎng'éguó,9yuè14rìdàodámòsīkē,zhīhòu,tāqǔdào柯nísībǎochèhuíbalí.
 1	1812	1812	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1812|LTranslit=1812
@@ -8687,6 +8981,7 @@
 27	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s295
+# parallel_id = zhgsd/dev295
 # text = 关于精灵之眼的介绍，将在下方『魔法』条目中会详以叙述。
 # translit = guānyújīnglíngzhīyǎndejièshào,jiāngzàixiàfāng“mófǎ”tiáomùzhōnghuìxiángyǐxùshù.
 1	关于	关于	ADP	IN	_	6	case	_	SpaceAfter=No|Translit=guānyú|LTranslit=guānyú
@@ -8711,6 +9006,7 @@
 20	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s296
+# parallel_id = zhgsd/dev296
 # text = 次年司马炎创立西晋，司马攸受封为齐王。
 # translit = cìniánsīmǎyánchuànglìxi晋,sīmǎ攸shòufēngwèiqíwáng.
 1	次年	次年	NOUN	NN	_	4	nmod:tmod	_	SpaceAfter=No|Translit=cìnián|LTranslit=cìnián
@@ -8727,6 +9023,7 @@
 12	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s297
+# parallel_id = zhgsd/dev297
 # text = 其后汲桑杀害东赢公司马腾，号称为颖报仇，于是起出司马颖的棺木，带着它行军，每有事都启奏司马颖，以行军令。
 # translit = qíhòu汲sāngshāhàidōng赢gōngsīmǎténg,hàochēngwèiyǐngbàochóu,yúshìqǐchūsīmǎyǐngdeguānmù,dàizhetāxíngjūn,měiyǒushìdōuqǐzòusīmǎyǐng,yǐxíngjūnlìng.
 1	其后	其后	NOUN	NN	_	34	nmod:tmod	_	SpaceAfter=No|Translit=qíhòu|LTranslit=qíhòu
@@ -8767,6 +9064,7 @@
 36	。	。	PUNCT	.	_	34	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s298
+# parallel_id = zhgsd/dev298
 # text = 合武铁路为沪汉蓉快速通道的一部分。
 # translit = héwǔtiělùwèi沪hàn蓉kuàisùtōngdàodeyībùfēn.
 1	合	合	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=hé|LTranslit=hé
@@ -8784,6 +9082,7 @@
 13	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s299
+# parallel_id = zhgsd/dev299
 # text = 变调夹最初的用途是调整吉他的音调，使其与演唱者的嗓音相协调。
 # translit = biàndiàojiāzuìchūdeyòngtúshìdiàozhěngjítādeyīndiào,shǐqíyǔyǎnchàngzhědesǎngyīnxiāngxiédiào.
 1	变调	变调	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=biàndiào|LTranslit=biàndiào
@@ -8809,6 +9108,7 @@
 21	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s300
+# parallel_id = zhgsd/dev300
 # text = 约11世纪，苯教大师贤钦鲁噶的弟子许耶罗布兴建了一座名叫“吉卡日香”的苯教寺院。
 # translit = yuē11shìjì,苯jiàodàshī贤qīnlǔ噶dedìzixǔyéluōbùxìngjiànleyīzuòmíngjiào“jíkǎrìxiāng”de苯jiàosìyuàn.
 1	约	约	ADV	RB	_	3	advmod	_	SpaceAfter=No|Translit=yuē|LTranslit=yuē
@@ -8836,6 +9136,7 @@
 23	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s301
+# parallel_id = zhgsd/dev301
 # text = 对于语言学家来说一般这是区分两种语言的标志。
 # translit = duìyúyǔyánxuéjiāláishuōyībānzhèshìqūfēnliǎngzhǒngyǔyándebiāozhì.
 1	对于	对于	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=duìyú|LTranslit=duìyú
@@ -8856,6 +9157,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s302
+# parallel_id = zhgsd/dev302
 # text = 相反的只会说吉大港语的人听不懂孟加拉语。
 # translit = xiāngfǎndezhǐhuìshuōjídàgǎngyǔderéntīngbùdǒng孟jiālāyǔ.
 1	相反	相反	ADJ	JJ	_	11	advmod	_	SpaceAfter=No|Translit=xiāngfǎn|LTranslit=xiāngfǎn
@@ -8876,6 +9178,7 @@
 16	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s303
+# parallel_id = zhgsd/dev303
 # text = 多斯桑托斯早于2007年便入选墨西哥国家足球队成为大国脚，在2009年也入选2009年美洲金杯的国家队名单，在赛事中合共射入两球及交出多次助攻，表现出色，协助墨西哥羸得第五次美洲金杯冠军。
 # translit = duōsīsāngtuōsīzǎoyú2007niánbiànrùxuǎnmòxigēguójiāzúqiúduìchéngwèidàguójiǎo,zài2009niányěrùxuǎn2009niánměizhōujīnbēideguójiāduìmíngdān,zàisàishìzhōnghégòngshèrùliǎngqiújíjiāochūduōcìzhùgōng,biǎoxiànchūsè,xiézhùmòxigē羸dedìwǔcìměizhōujīnbēiguānjūn.
 1	多斯桑托斯	多斯桑托斯	PROPN	NNP	_	47	nsubj	_	SpaceAfter=No|Translit=duōsīsāngtuōsī|LTranslit=duōsīsāngtuōsī
@@ -8935,6 +9238,7 @@
 55	。	。	PUNCT	.	_	47	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s304
+# parallel_id = zhgsd/dev304
 # text = 2004年5月6日，吉田美和选在生日这天，透过网站向世人宣布与末田健闪电结婚的消息。
 # translit = 2004nián5yuè6rì,jítiánměihéxuǎnzàishēngrìzhètiān,tòuguòwǎngzhànxiàngshìrénxuānbùyǔmòtiánjiànshǎndiànjiéhūndexiāoxi.
 1	2004	2004	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2004|LTranslit=2004
@@ -8967,6 +9271,7 @@
 28	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s305
+# parallel_id = zhgsd/dev305
 # text = 斯诺克以外，怀特亦曾参与周星驰所主演的电影龙的传人，饰演其真实身份--职业斯诺克球手。
 # translit = sī诺kèyǐwài,huáitèyìcéngcānyǔzhōuxīngchísuǒzhǔyǎndediànyǐnglóngdechuánrén,shìyǎnqízhēnshíshēnfèn--zhíyèsī诺kèqiúshǒu.
 1	斯诺克	斯诺克	NOUN	NN	_	7	obl	_	SpaceAfter=No|Translit=sī诺kè|LTranslit=sī诺kè
@@ -8997,6 +9302,7 @@
 26	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s306
+# parallel_id = zhgsd/dev306
 # text = 同义镇是中国黑龙江省齐齐哈尔市讷河市下辖的一个镇。
 # translit = tóngyìzhènshìzhōngguóhēilóngjiāngshěngqíqíhā'ěrshì讷héshìxiàxiádeyīgèzhèn.
 1	同义	同义	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=tóngyì|LTranslit=tóngyì
@@ -9018,6 +9324,7 @@
 17	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s307
+# parallel_id = zhgsd/dev307
 # text = 名人会议成员包括亲王、贵族、大主教、大法官，某些情况下，也包括主要城镇的官员。
 # translit = míngrénhuìyìchéngyuánbāokuòqīnwáng,guìzú,dàzhǔjiào,dàfǎguān,mǒuxiēqíngkuàngxià,yěbāokuòzhǔyàochéngzhèndeguānyuán.
 1	名人	名人	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=míngrén|LTranslit=míngrén
@@ -9047,6 +9354,7 @@
 25	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s308
+# parallel_id = zhgsd/dev308
 # text = 总括来说，名人会议旨在维持国家繁荣安定。
 # translit = zǒngkuòláishuō,míngrénhuìyì旨zàiwéichíguójiāfánróng'āndìng.
 1	总括	总括	VERB	VV	_	3	advcl	_	SpaceAfter=No|Translit=zǒngkuò|LTranslit=zǒngkuò
@@ -9064,6 +9372,7 @@
 13	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s309
+# parallel_id = zhgsd/dev309
 # text = 上映第四周为日本黄金周过后的第一周，柯南历届剧场版票房通常从这时期开始增幅放缓，但M 17却依然成为周票房榜冠军，蝉联四周冠军。
 # translit = shàngyìngdìsìzhōuwèirìběnhuángjīnzhōuguòhòudedìyīzhōu,柯nánlìjièjùchǎngbǎnpiàofángtōngchángcóngzhèshíqīkāishǐzēngfúfànghuǎn,dànM 17quèyīránchéngwèizhōupiàofángbǎngguānjūn,chánliánsìzhōuguānjūn.
 1	上映	上映	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=shàngyìng|LTranslit=shàngyìng
@@ -9110,6 +9419,7 @@
 42	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s310
+# parallel_id = zhgsd/dev310
 # text = 曾经花了30年的时间冒险的冒险家，打算和好友分享他的宝物和经历演说，然而为了如此还邀请福尔摩斯与华生来参加展览。
 # translit = céngjīnghuāle30niándeshíjiānmàoxiǎndemàoxiǎnjiā,dǎsuànhéhǎoyoufēnxiǎngtādebǎowùhéjīnglìyǎnshuō,rán'érwèilerúcǐháiyāoqǐngfú'ěrmósīyǔhuáshēngláicānjiāzhǎnlǎn.
 1	曾经	曾经	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=céngjīng|LTranslit=céngjīng
@@ -9149,6 +9459,7 @@
 35	。	。	PUNCT	.	_	28	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s311
+# parallel_id = zhgsd/dev311
 # text = 1934年，他共为日本国家足球队出场1次，打进1球。
 # translit = 1934nián,tāgòngwèirìběnguójiāzúqiúduìchūchǎng1cì,dǎjìn1qiú.
 1	1934	1934	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1934|LTranslit=1934
@@ -9171,6 +9482,7 @@
 18	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s312
+# parallel_id = zhgsd/dev312
 # text = 校园中有一条南北向的大道将校园分成东西两部。
 # translit = xiàoyuánzhōngyǒuyītiáonánběixiàngdedàdàojiāngxiàoyuánfēnchéngdōngxiliǎngbù.
 1	校园	校园	NOUN	NN	_	3	nsubj	_	SpaceAfter=No|Translit=xiàoyuán|LTranslit=xiàoyuán
@@ -9190,6 +9502,7 @@
 15	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s313
+# parallel_id = zhgsd/dev313
 # text = 后港体育场是新加坡的一所综合性体育场，球场位于新加坡后港地区，最多可以同时容纳3,400名观众，球场每天早晨对大众开放晨练和慢跑活动，球场目前是新加坡职业足球联赛球队盛港榜鹅队的主场。
 # translit = hòugǎngtǐyùchǎngshìxīnjiāpōdeyīsuǒzōnghéxìngtǐyùchǎng,qiúchǎngwèiyúxīnjiāpōhòugǎngdeqū,zuìduōkěyǐtóngshíróngnà3,400míngguānzhòng,qiúchǎngměitiānzǎochenduìdàzhòngkāifàngchenliànhémànpǎohuódòng,qiúchǎngmùqiánshìxīnjiāpōzhíyèzúqiúliánsàiqiúduìshènggǎngbǎng'éduìdezhǔchǎng.
 1	后港	后港	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=hòugǎng|LTranslit=hòugǎng
@@ -9246,6 +9559,7 @@
 52	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s314
+# parallel_id = zhgsd/dev314
 # text = 当然由于我们已经没有办法脱离现代生活方式的制约，而各种现代主义所带来的恶果，并不足以完全否定现代文明的生活。
 # translit = dāngrányóuyúwǒmenyǐjīngméiyǒubànfǎtuōlíxiàndàishēnghuófāngshìdezhìyuē,'érgèzhǒngxiàndàizhǔyìsuǒdàiláide'èguǒ,bìngbùzúyǐwánquánfǒudìngxiàndàiwénmíngdeshēnghuó.
 1	当然	当然	ADV	RB	_	25	advmod	_	SpaceAfter=No|Translit=dāngrán|LTranslit=dāngrán
@@ -9283,6 +9597,7 @@
 33	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s315
+# parallel_id = zhgsd/dev315
 # text = 这种行为本身造成了一种对后现代理解的偏激和错位。
 # translit = zhèzhǒngxíngwèiběnshēnzàochéngleyīzhǒngduìhòuxiàndàilǐjiědepiānjīhécuòwèi.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -9304,6 +9619,7 @@
 17	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s316
+# parallel_id = zhgsd/dev316
 # text = 除了怀疑之外，他们的思想在理性思维者看来几乎是凝滞的，他们只能寄生在现代启蒙理性之上作个永远的捣蛋鬼。
 # translit = chúlehuáiyízhīwài,tāmendesīxiǎngzàilǐxìngsīwéizhěkànláijǐhushìníng滞de,tāmenzhǐnéngjìshēngzàixiàndàiqǐménglǐxìngzhīshàngzuògèyǒngyuǎndedǎodànguǐ.
 1	除	除	VERB	VV	_	16	advcl	_	SpaceAfter=No|Translit=chú|LTranslit=chú
@@ -9342,6 +9658,7 @@
 34	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s317
+# parallel_id = zhgsd/dev317
 # text = 她是日本第一位女性宇航员，也是首位两度登上太空的日本宇航员。
 # translit = tāshìrìběndìyīwèinǚxìngyǔhángyuán,yěshìshǒuwèiliǎngdùdēngshàngtàikōngderìběnyǔhángyuán.
 1	她	她	PRON	PRP	Person=3	19	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -9366,6 +9683,7 @@
 20	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s318
+# parallel_id = zhgsd/dev318
 # text = 自1992年以来，向井千秋是德克萨斯州休斯敦贝勒医学院外科研究讲师。
 # translit = zì1992niányǐlái,xiàngjǐngqiānqiūshìdékèsàsīzhōuxiūsī敦bèilēiyīxuéyuànwàikēyánjiūjiǎngshī.
 1	自	自	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zì|LTranslit=zì
@@ -9388,6 +9706,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s319
+# parallel_id = zhgsd/dev319
 # text = 向则错是一个位于中国西藏自治区日喀则地区的湖泊，面积约为1.69平方千米，属于青藏高原。
 # translit = xiàngzécuòshìyīgèwèiyúzhōngguóxicángzìzhìqūrì喀zédeqūdehúpō,miànjīyuēwèi1.69píngfāngqiānmǐ,shǔyúqīngcánggāoyuán.
 1	向则错	向则错	PROPN	NNP	_	14	nsubj	_	SpaceAfter=No|Translit=xiàngzécuò|LTranslit=xiàngzécuò
@@ -9418,6 +9737,7 @@
 26	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s320
+# parallel_id = zhgsd/dev320
 # text = 向岛TB（向岛本线料金所）是位于广岛县尾道市的西濑户自动车道（濑户内岛波海道）之收费站。
 # translit = xiàngdǎoTB(xiàngdǎoběnxiànliàojīnsuǒ)shìwèiyúguǎngdǎoxiànwěidàoshìdexi濑hùzìdòngchēdào(濑hùnèidǎobōhǎidào)zhīshōufèizhàn.
 1	向岛	向岛	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=xiàngdǎo|LTranslit=xiàngdǎo
@@ -9452,6 +9772,7 @@
 30	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s321
+# parallel_id = zhgsd/dev321
 # text = 独特的地理条件和气候特点造就了春夏间云山雾海的奇景，使向阳成为夏日休闲避暑的圣地，同时为我乡名优特水果、速生丰产林、食用菌、有机茶叶等绿色农业成规模开发提供了得天独厚的自然条件。
 # translit = dútèdedelǐtiáojiànhéqìhoutèdiǎnzàojiùlechūnxiàjiānyúnshānwùhǎideqíjǐng,shǐxiàngyángchéngwèixiàrìxiūxiánbìshǔdeshèngde,tóngshíwèiwǒxiāngmíngyōutèshuǐguǒ,sùshēngfēngchǎnlín,shíyòngjūn,yǒujīcháyèděnglǜsènóngyèchéngguīmókāifātígōngledetiāndúhòudezìrántiáojiàn.
 1	独特	独特	ADJ	JJ	_	4	amod	_	SpaceAfter=No|Translit=dútè|LTranslit=dútè
@@ -9510,6 +9831,7 @@
 54	。	。	PUNCT	.	_	48	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s322
+# parallel_id = zhgsd/dev322
 # text = 伊吕西60年代师从格罗滕迪克，参与了代数几何讨论班。
 # translit = yī吕xi60niándàishīcónggéluō滕díkè,cānyǔledàishùjǐhétǎolùnbān.
 1	伊吕西	伊吕西	PROPN	NNP	_	7	nsubj	_	SpaceAfter=No|Translit=yī吕xi|LTranslit=yī吕xi
@@ -9527,6 +9849,7 @@
 13	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s323
+# parallel_id = zhgsd/dev323
 # text = 宋太宗去世后，内侍王继恩密谋废掉太子，另立君王。
 # translit = 宋tàizōngqùshìhòu,nèishìwángjì'ēnmìmóufèidiàotàizi,lìnglìjūnwáng.
 1	宋	宋	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=宋|LTranslit=宋
@@ -9546,6 +9869,7 @@
 15	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s324
+# parallel_id = zhgsd/dev324
 # text = 此外，君主要做到珍惜人才，任人为贤，激励人们在各行各业做好本职工作。
 # translit = cǐwài,jūnzhǔyàozuòdàozhēnxīréncái,rènrénwèi贤,jīlìrénmenzàigèxínggèyèzuòhǎoběnzhígōngzuò.
 1	此外	此外	NOUN	NN	_	11	obl	_	SpaceAfter=No|Translit=cǐwài|LTranslit=cǐwài
@@ -9569,6 +9893,7 @@
 19	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s325
+# parallel_id = zhgsd/dev325
 # text = 1048年帝国与塞尔柱人在亚美尼亚发生冲突，但不久即缔结和约。
 # translit = 1048niándìguóyǔsāi'ěrzhùrénzàiyàměiníyàfāshēngchōngtū,dànbùjiǔjídìjiéhéyuē.
 1	1048	1048	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1048|LTranslit=1048
@@ -9590,6 +9915,7 @@
 17	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s326
+# parallel_id = zhgsd/dev326
 # text = 这次叛乱大大削弱了帝国在巴尔干地区的防御力量，导致1048年佩切涅格人入侵该地区，并在此后5年多次进行劫掠，造成很大破坏。
 # translit = zhècìpànluàndàdàxuēruòledìguózàiba'ěrgàndeqūdefángyùlìliàng,dǎozhì1048niánpèiqiè涅gérénrùqīngāideqū,bìngzàicǐhòu5niánduōcìjìnxíng劫'è,zàochénghěndàpòhuài.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -9631,6 +9957,7 @@
 37	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s327
+# parallel_id = zhgsd/dev327
 # text = 像富人住宅一样，教堂和修道院通常也带有花园。
 # translit = xiàngfùrénzhùzháiyīyàng,jiàotánghéxiūdàoyuàntōngchángyědàiyǒuhuāyuán.
 1	像	像	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=xiàng|LTranslit=xiàng
@@ -9650,6 +9977,7 @@
 15	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s328
+# parallel_id = zhgsd/dev328
 # text = 普通平民为逃避兵役竟采取自残的办法。
 # translit = pǔtōngpíngmínwèitáobìbīngyìjìngcǎiqǔzìcándebànfǎ.
 1	普通	普通	ADJ	JJ	_	2	amod	_	SpaceAfter=No|Translit=pǔtōng|LTranslit=pǔtōng
@@ -9665,6 +9993,7 @@
 11	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s329
+# parallel_id = zhgsd/dev329
 # text = 吲哚乙酸也可以用化学方法合成。
 # translit = 吲哚yǐsuānyěkěyǐyònghuàxuéfāngfǎhéchéng.
 1	吲哚乙酸	吲哚乙酸	NOUN	NN	_	7	nsubj	_	SpaceAfter=No|Translit=吲哚yǐsuān|LTranslit=吲哚yǐsuān
@@ -9677,6 +10006,7 @@
 8	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s330
+# parallel_id = zhgsd/dev330
 # text = 吴廷琰的活动使他实质上获得了公开身份，这时法国人决定让步，以安抚民族主义鼓动者，还要求他劝说保大皇帝加入他们。
 # translit = 吴tíng琰dehuódòngshǐtāshízhìshànghuòdelegōngkāishēnfèn,zhèshífǎguórénjuédìngràngbù,yǐ'ānfǔmínzúzhǔyìgǔdòngzhě,háiyàoqiútāquànshuōbǎodàhuángdìjiārùtāmen.
 1	吴	吴	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=吴|LTranslit=吴
@@ -9717,6 +10047,7 @@
 36	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s331
+# parallel_id = zhgsd/dev331
 # text = 吴之父亲将其送往英国寄宿学校读高中，但他又因偷窃而被学校开除。
 # translit = 吴zhīfùqīnjiāngqísòngwǎngyīngguójìsùxuéxiàodúgāozhōng,dàntāyòuyīntōuqiè'érbèixuéxiàokāichú.
 1	吴	吴	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=吴|LTranslit=吴
@@ -9743,6 +10074,7 @@
 22	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s332
+# parallel_id = zhgsd/dev332
 # text = 吴念真的父亲来自嘉义县民雄，到达瑞芳，在李建兴兄弟创办的瑞三煤矿工作。
 # translit = 吴niànzhēndefùqīnláizìjiāyìxiànmínxióng,dàodáruì芳,zàilijiànxìngxiōngdìchuàngbànderuìsānméikuànggōngzuò.
 1	吴	吴	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=吴|LTranslit=吴
@@ -9770,6 +10102,7 @@
 23	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s333
+# parallel_id = zhgsd/dev333
 # text = 消息传得很快，日本报章也报道中国发现了天才神童。
 # translit = xiāoxichuándehěnkuài,rìběnbàozhāngyěbàodàozhōngguófāxiànletiāncáishéntóng.
 1	消息	消息	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=xiāoxi|LTranslit=xiāoxi
@@ -9789,6 +10122,7 @@
 15	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s334
+# parallel_id = zhgsd/dev334
 # text = 吴曾任跨国机构信昌工程有限公司之常务董事。
 # translit = 吴céngrènkuàguójīgòuxìn昌gōngchéngyǒuxiàngōngsīzhīchángwu董shì.
 1	吴	吴	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit=吴|LTranslit=吴
@@ -9806,6 +10140,7 @@
 13	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s335
+# parallel_id = zhgsd/dev335
 # text = 三桂治军严谨，精锐骑兵一千人，分二十队，五十人一队，每队设一领骑官，吴三桂在自己的靴筒上放这二十名领骑官姓名，一旦抽中谁，便呼叫某领骑官，该领骑官即统五十人骑队，跟随他冲锋陷阵，可谓“无往不利”，是明末最后一支有战力的铁骑部队。
 # translit = sān桂zhìjūnyánjǐn,jīngruìqíbīngyīqiānrén,fēn'èrshíduì,wǔshírényīduì,měiduìshèyīlǐngqíguān,吴sān桂zàizìjǐdexuētǒngshàngfàngzhè'èrshímínglǐngqíguānxìngmíng,yīdànchōuzhōngshuí,biànhūjiàomǒulǐngqíguān,gāilǐngqíguānjítǒngwǔshírénqíduì,gēnsuítāchōngfēngxiànzhèn,kěwèi“wúwǎngbùlì”,shìmíngmòzuìhòuyīzhīyǒuzhànlìdetiěqíbùduì.
 1	三桂	三桂	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=sān桂|LTranslit=sān桂
@@ -9891,6 +10226,7 @@
 81	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s336
+# parallel_id = zhgsd/dev336
 # text = 之后吴三桂转成为清军先驱，率军攻打陕西、四川等地的李自成、张献忠余部。
 # translit = zhīhòu吴sān桂zhuǎnchéngwèiqīngjūnxiānqū,lǜjūngōngdǎ陕xi,sìchuānděngdedelizìchéng,zhāngxiànzhōngyúbù.
 1	之后	之后	NOUN	NN	_	11	nmod:tmod	_	SpaceAfter=No|Translit=zhīhòu|LTranslit=zhīhòu
@@ -9919,6 +10255,7 @@
 24	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s337
+# parallel_id = zhgsd/dev337
 # text = 顺治十七年，朝廷以赋税不足，令吴三桂裁减兵员。
 # translit = shùnzhìshíqīnián,cháotíngyǐ赋shuìbùzú,lìng吴sān桂cáijiǎnbīngyuán.
 1	顺治	顺治	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=shùnzhì|LTranslit=shùnzhì
@@ -9938,6 +10275,7 @@
 15	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s338
+# parallel_id = zhgsd/dev338
 # text = 故事的高潮在于周润发在手里抱着婴儿嘴里哼着摇篮曲哄小孩睡觉的情况下，一一解决歹徒并跳出窗外，婴儿仍是安然无恙。
 # translit = gùshìdegāocháozàiyúzhōurùnfāzàishǒulǐbàozheyīngrzuǐlǐhēngzheyáolánqūhōngxiǎoháishuìjuédeqíngkuàngxià,yīyījiějué歹túbìngtiàochūchuāngwài,yīngrréngshì'ānránwú恙.
 1	故事	故事	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=gùshì|LTranslit=gùshì
@@ -9977,6 +10315,7 @@
 35	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s339
+# parallel_id = zhgsd/dev339
 # text = 2008年6月28日，成立中国首个以同性恋者及其亲友为主体的民间组织----同性恋亲友会并任会长3年半。
 # translit = 2008nián6yuè28rì,chénglìzhōngguóshǒugèyǐtóngxìngliànzhějíqíqīnyouwèizhǔtǐdemínjiānzǔzhī----tóngxìngliànqīnyouhuìbìngrènhuìzhǎng3niánbàn.
 1	2008	2008	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2008|LTranslit=2008
@@ -10015,6 +10354,7 @@
 34	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s340
+# parallel_id = zhgsd/dev340
 # text = 而为了补充吴桂贤的文化知识，她曾被安排到西北大学学习；于1968年毕业。
 # translit = 'érwèilebǔchōng吴桂贤dewénhuàzhīshi,tācéngbèi'ānpáidàoxiběidàxuéxuéxí;yú1968niánbìyè.
 1	而	而	SCONJ	RB	_	22	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -10042,6 +10382,7 @@
 23	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s341
+# parallel_id = zhgsd/dev341
 # text = 该建筑现为一般保护等级历史风貌建筑。
 # translit = gāijiànzhùxiànwèiyībānbǎohùděngjílìshǐfēngmàojiànzhù.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -10057,6 +10398,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s342
+# parallel_id = zhgsd/dev342
 # text = 2004年初，吴金贵被调入中国国家足球队，出任荷兰主教练阿里·哈恩的助理，但是很快因为对于“业务的不同意见”而离开。
 # translit = 2004niánchū,吴jīnguìbèidiàorùzhōngguóguójiāzúqiúduì,chūrènhélánzhǔjiàoliàn'ālǐ·hā'ēndezhùlǐ,dànshìhěnkuàiyīnwèiduìyú“yèwudebùtóngyìjiàn”'érlíkāi.
 1	2004	2004	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2004|LTranslit=2004
@@ -10097,6 +10439,7 @@
 36	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s343
+# parallel_id = zhgsd/dev343
 # text = Elijah之后由Elena取回匕首，重新立规则对付Klaus。
 # translit = ElijahzhīhòuyóuElenaqǔhuí匕shǒu,zhòngxīnlìguīzéduìfùKlaus.
 1	Elijah	Elijah	X	FW	Foreign=Yes	11	nsubj	_	SpaceAfter=No|Translit=Elijah|LTranslit=Elijah
@@ -10114,6 +10457,7 @@
 13	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s344
+# parallel_id = zhgsd/dev344
 # text = Katherine自杀，因此成了吸血鬼。
 # translit = Katherinezìshā,yīncǐchénglexīxuèguǐ.
 1	Katherine	Katherine	X	FW	Foreign=Yes	6	nsubj	_	SpaceAfter=No|Translit=Katherine|LTranslit=Katherine
@@ -10128,6 +10472,7 @@
 10	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s345
+# parallel_id = zhgsd/dev345
 # text = Lucy在月光石上施咒，交给Katherine。
 # translit = Lucyzàiyuèguāngshíshàngshīzhòu,jiāogěiKatherine.
 1	Lucy	Lucy	X	FW	Foreign=Yes	8	nsubj	_	SpaceAfter=No|Translit=Lucy|LTranslit=Lucy
@@ -10142,6 +10487,7 @@
 10	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s346
+# parallel_id = zhgsd/dev346
 # text = 最初在1996年未上映的试播节目中罗森博格这个角色是让Riff Regan饰演，但在确定会上映并重新征选角色后，Hannigan参加了罗森博格这个角色的征选。
 # translit = zuìchūzài1996niánwèishàngyìngdeshìbōjiémùzhōngluōsēnbógézhègèjiǎosèshìràngRiff Reganshìyǎn,dànzàiquèdìnghuìshàngyìngbìngzhòngxīnzhēngxuǎnjiǎosèhòu,Hannigancānjiāleluōsēnbógézhègèjiǎosèdezhēngxuǎn.
 1	最初	最初	NOUN	NN	_	15	nmod:tmod	_	SpaceAfter=No|Translit=zuìchū|LTranslit=zuìchū
@@ -10187,6 +10533,7 @@
 41	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s347
+# parallel_id = zhgsd/dev347
 # text = 因为天生身体虚弱，从没在“夜之社交界”里出现过。
 # translit = yīnwèitiānshēngshēntǐxūruò,cóngméizài“yèzhīshèjiāojiè”lǐchūxiànguò.
 1	因为	因为	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -10209,6 +10556,7 @@
 18	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s348
+# parallel_id = zhgsd/dev348
 # text = 古斯塔夫·克林姆创作这幅画时为45岁，当时他仍然跟母亲及两个尚未结婚的姐妹居住在一起。
 # translit = gǔsītǎfu·kèlínmǔchuàngzuòzhèfúhuàshíwèi45suì,dāngshítāréngrángēnmǔqīnjíliǎnggèshàngwèijiéhūndejiemèijūzhùzàiyīqǐ.
 1	古斯塔夫	古斯塔夫	PROPN	NNP	_	11	nsubj	_	SpaceAfter=No|Translit=gǔsītǎfu|LTranslit=gǔsītǎfu
@@ -10242,6 +10590,7 @@
 29	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s349
+# parallel_id = zhgsd/dev349
 # text = 1988年11月15日，他于伦敦病逝，终年73岁。
 # translit = 1988nián11yuè15rì,tāyúlún敦bìngshì,zhōngnián73suì.
 1	1988	1988	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1988|LTranslit=1988
@@ -10262,6 +10611,7 @@
 16	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s350
+# parallel_id = zhgsd/dev350
 # text = 可是，吕卫伦接任会长的时候，正值英国文化协会的低潮，在1960年代，由于政府削减资助等原因，协会被迫先后结束在缅甸、斐济、加勒比海和非洲及中东部份地区的工作，并将协会的服务对象逐步缩窄至西欧地区，工作性质也限制到只有艺术、科学和科技领域的交流层面，使协会的规模不断萎缩。
 # translit = kěshì,吕wèilúnjiērènhuìzhǎngdeshíhou,zhèngzhíyīngguówénhuàxiéhuìdedīcháo,zài1960niándài,yóuyúzhèngfǔxuējiǎnzīzhùděngyuányīn,xiéhuìbèipòxiānhòujiéshùzài缅diān,斐jì,jiālēibǐhǎihéfēizhōujízhōngdōngbùfèndeqūdegōngzuò,bìngjiāngxiéhuìdefúwuduìxiàngzhúbùsuōzhǎizhìxi'ōudeqū,gōngzuòxìngzhìyěxiànzhìdàozhǐyǒuyìshù,kēxuéhékējìlǐngyùdejiāoliúcéngmiàn,shǐxiéhuìdeguīmóbùduàn萎suō.
 1	可是	可是	SCONJ	RB	_	10	mark	_	SpaceAfter=No|Translit=kěshì|LTranslit=kěshì
@@ -10350,6 +10700,7 @@
 84	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s351
+# parallel_id = zhgsd/dev351
 # text = 吕卫伦在纽西兰工作期间，也曾担任过与教育无关的公职。
 # translit = 吕wèilúnzàiniǔxilángōngzuòqījiān,yěcéngdānrènguòyǔjiàoyùwúguāndegōngzhí.
 1	吕卫伦	吕卫伦	PROPN	NNP	_	9	nsubj	_	SpaceAfter=No|Translit=吕wèilún|LTranslit=吕wèilún
@@ -10370,6 +10721,7 @@
 16	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s352
+# parallel_id = zhgsd/dev352
 # text = 在出任协会会长以前，他早在1968年至1972年任英国文化协会英联邦大学交流委员会委员，因此对协会有一定认识。
 # translit = zàichūrènxiéhuìhuìzhǎngyǐqián,tāzǎozài1968niánzhì1972niánrènyīngguówénhuàxiéhuìyīngliánbāngdàxuéjiāoliúwěiyuánhuìwěiyuán,yīncǐduìxiéhuìyǒuyīdìngrènshi.
 1	在	在	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -10408,6 +10760,7 @@
 34	。	。	PUNCT	.	_	31	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s353
+# parallel_id = zhgsd/dev353
 # text = 尽管他的钱币象征意味雄厚，但在政策上可能趋向防御性质。
 # translit = jǐnguǎntādeqiánbìxiàngzhēngyìwèixiónghòu,dànzàizhèngcèshàngkěnéngqūxiàngfángyùxìngzhì.
 1	尽管	尽管	ADP	IN	_	7	case	_	SpaceAfter=No|Translit=jǐnguǎn|LTranslit=jǐnguǎn
@@ -10429,6 +10782,7 @@
 17	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s354
+# parallel_id = zhgsd/dev354
 # text = 香港马会亦暂时吊销其骑师牌照，停赛四个月。
 # translit = xiānggǎngmǎhuìyìzànshídiàoxiāoqíqíshīpáizhào,tíngsàisìgèyuè.
 1	香港	香港	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=xiānggǎng|LTranslit=xiānggǎng
@@ -10447,6 +10801,7 @@
 14	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s355
+# parallel_id = zhgsd/dev355
 # text = 辛亥革命爆发后，他被蜀军政府派到上海购买军械，并与各省都督府代表联合会代表在湖北会议。
 # translit = xīn亥gémìngbàofāhòu,tābèi蜀jūnzhèngfǔpàidàoshànghǎigòumǎijūnxiè,bìngyǔgèshěngdōudūfǔdàibiǎoliánhéhuìdàibiǎozàihúběihuìyì.
 1	辛亥	辛亥	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=xīn亥|LTranslit=xīn亥
@@ -10479,6 +10834,7 @@
 28	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s356
+# parallel_id = zhgsd/dev356
 # text = 他是北京大学第一个讲欧洲文学史的教授。
 # translit = tāshìběijīngdàxuédìyīgèjiǎng'ōuzhōuwénxuéshǐdejiàoshòu.
 1	他	他	PRON	PRP	Person=3	12	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -10496,6 +10852,7 @@
 13	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s357
+# parallel_id = zhgsd/dev357
 # text = 但可以举一事为例，他说他喜欢涉览笔记，中国的，他几乎都看过。
 # translit = dànkěyǐjǔyīshìwèilì,tāshuōtāxǐhuanshèlǎnbǐjì,zhōngguóde,tājǐhudōukànguò.
 1	但	但	SCONJ	RB	_	3	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -10524,6 +10881,7 @@
 24	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s358
+# parallel_id = zhgsd/dev358
 # text = 这情况，轻一些说是他们有了自己的独有的风格，重一些说是别人办不了。
 # translit = zhèqíngkuàng,qīngyīxiēshuōshìtāmenyǒulezìjǐdedúyǒudefēnggé,zhòngyīxiēshuōshìbiérénbànbùle.
 1	这	这	DET	DT	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -10553,6 +10911,7 @@
 25	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s359
+# parallel_id = zhgsd/dev359
 # text = 从第二年开始，周俊三渐转球队辅助角色，上场时间愈来愈少。
 # translit = cóngdì'èrniánkāishǐ,zhōu俊sānjiànzhuǎnqiúduìfǔzhùjiǎosè,shàngchǎngshíjiānyùláiyùshǎo.
 1	从	从	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=cóng|LTranslit=cóng
@@ -10574,6 +10933,7 @@
 17	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s360
+# parallel_id = zhgsd/dev360
 # text = 民国6年（1917年），段祺瑞执政，国会再度解散。
 # translit = mínguó6nián(1917nián),duàn祺ruìzhízhèng,guóhuìzàidùjiěsàn.
 1	民国	民国	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=mínguó|LTranslit=mínguó
@@ -10594,6 +10954,7 @@
 16	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s361
+# parallel_id = zhgsd/dev361
 # text = 汪精卫从重庆脱出并受到日本保护之际，周化人归国辅佐汪。
 # translit = wāngjīngwèicóngzhòngqìngtuōchūbìngshòudàorìběnbǎohùzhījì,zhōuhuàrénguīguófǔ佐wāng.
 1	汪	汪	PROPN	NNP	_	7	nsubj	_	SpaceAfter=No|Translit=wāng|LTranslit=wāng
@@ -10616,6 +10977,7 @@
 18	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s362
+# parallel_id = zhgsd/dev362
 # text = 1946年10月19日他被首都高等法院判处死刑，1947年（民国36年）5月上诉仍被维持原判，但迟迟未执行枪决。
 # translit = 1946nián10yuè19rìtābèishǒudōugāoděngfǎyuànpànchùsǐxíng,1947nián(mínguó36nián)5yuèshàngsuréngbèiwéichíyuánpàn,dànchíchíwèizhíxíngqiāngjué.
 1	1946	1946	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1946|LTranslit=1946
@@ -10655,6 +11017,7 @@
 35	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s363
+# parallel_id = zhgsd/dev363
 # text = 光绪三十二年（1906年）任山东大学堂总监督，任职一年。
 # translit = guāngxùsānshí'èrnián(1906nián)rènshāndōngdàxuétángzǒngjiāndū,rènzhíyīnián.
 1	光绪	光绪	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=guāngxù|LTranslit=guāngxù
@@ -10677,6 +11040,7 @@
 18	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s364
+# parallel_id = zhgsd/dev364
 # text = 西戎是对中国古代西部部族的统称，长期威胁西周王朝的西部边境。
 # translit = xi戎shìduìzhōngguógǔdàixibùbùzúdetǒngchēng,zhǎngqīwēixiéxizhōuwángcháodexibùbiānjìng.
 1	西戎	西戎	PROPN	NNP	_	12	nsubj	_	SpaceAfter=No|Translit=xi戎|LTranslit=xi戎
@@ -10699,6 +11063,7 @@
 18	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s365
+# parallel_id = zhgsd/dev365
 # text = 后来，周志仁随护国军赴四川，转战泸州、叙府，后在四川战死。
 # translit = hòulái,zhōuzhìrénsuíhùguójūnfùsìchuān,zhuǎnzhàn泸zhōu,xùfǔ,hòuzàisìchuānzhànsǐ.
 1	后来	后来	NOUN	NN	_	11	nmod:tmod	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -10723,6 +11088,7 @@
 20	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s366
+# parallel_id = zhgsd/dev366
 # text = 周成建是中国的著名浙商及企业家，2009年以个人资产达136亿元人民币上榜福布斯中国富豪榜。
 # translit = zhōuchéngjiànshìzhōngguódezhemíng浙shāngjíqǐyèjiā,2009niányǐgèrénzīchǎndá136yìyuánrénmínbìshàngbǎngfúbùsīzhōngguófùháobǎng.
 1	周	周	PROPN	NNP	_	23	nsubj	_	SpaceAfter=No|Translit=zhōu|LTranslit=zhōu
@@ -10755,6 +11121,7 @@
 28	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s367
+# parallel_id = zhgsd/dev367
 # text = 晚年留居北京，常与恩施樊增祥、应山左绍佐以诗文唱和，号“楚中三老”。
 # translit = wǎnniánliújūběijīng,chángyǔ'ēnshī樊zēngxiáng,yīngshānzuǒshào佐yǐshīwénchànghé,hào“chuzhōngsānlǎo”.
 1	晚年	晚年	NOUN	NN	_	2	nmod:tmod	_	SpaceAfter=No|Translit=wǎnnián|LTranslit=wǎnnián
@@ -10783,6 +11150,7 @@
 24	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s368
+# parallel_id = zhgsd/dev368
 # text = 最小的弟弟周渝继承爸爸的思想，将紫藤庐经营成台北市独具一格的文化茶馆，成为台北市市定古迹。
 # translit = zuìxiǎodedìdìzhōu渝jìchéngbàbàdesīxiǎng,jiāngzǐténg庐jīngyíngchéngtáiběishìdújùyīgédewénhuàcháguǎn,chéngwèitáiběishìshìdìnggǔjī.
 1	最小	最小	ADJ	JJ	_	3	amod	_	SpaceAfter=No|Translit=zuìxiǎo|LTranslit=zuìxiǎo
@@ -10817,6 +11185,7 @@
 30	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s369
+# parallel_id = zhgsd/dev369
 # text = 有人说这是裴世清见到的秦王国。
 # translit = yǒurénshuōzhèshì裴shìqīngjiàndàode秦wángguó.
 1	有	有	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
@@ -10833,6 +11202,7 @@
 12	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s370
+# parallel_id = zhgsd/dev370
 # text = 1912年，调任回浙江，出任浙江省高等审判厅书记官长。
 # translit = 1912nián,diàorènhuí浙jiāng,chūrèn浙jiāngshěnggāoděngshěnpàntīngshūjìguānzhǎng.
 1	1912	1912	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1912|LTranslit=1912
@@ -10853,6 +11223,7 @@
 16	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s371
+# parallel_id = zhgsd/dev371
 # text = 1932年，周骏彦出任南京国民政府军政部军需署署长，后擢升至陆军军需总监，陆军中将军衔，是为周骏彦职业生涯顶点。
 # translit = 1932nián,zhōu骏彦chūrènnánjīngguómínzhèngfǔjūnzhèngbùjūnxūshǔshǔzhǎng,hòu擢shēngzhìlùjūnjūnxūzǒngjiān,lùjūnzhōngjiāngjūnxián,shìwèizhōu骏彦zhíyèshēng涯dǐngdiǎn.
 1	1932	1932	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1932|LTranslit=1932
@@ -10891,6 +11262,7 @@
 34	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s372
+# parallel_id = zhgsd/dev372
 # text = 周骏彦早年曾在家乡奉化县的龙津学堂担任学监。
 # translit = zhōu骏彦zǎoniáncéngzàijiāxiāngfènghuàxiàndelóngjīnxuétángdānrènxuéjiān.
 1	周	周	PROPN	NNP	_	12	nsubj	_	SpaceAfter=No|Translit=zhōu|LTranslit=zhōu
@@ -10909,6 +11281,7 @@
 14	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s373
+# parallel_id = zhgsd/dev373
 # text = 幸得卫将军呼延瑜击杀了陈安之弟陈集，让刘曜顺利撤军。
 # translit = xìngdewèijiāngjūnhūyán瑜jīshālechén'ānzhīdìchénjí,ràng刘曜shùnlìchèjūn.
 1	幸得	幸得	VERB	VV	_	15	csubj	_	SpaceAfter=No|Translit=xìngde|LTranslit=xìngde
@@ -10933,6 +11306,7 @@
 20	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s374
+# parallel_id = zhgsd/dev374
 # text = 玩家以地下军新成员与达夏取得联络，从达夏那玩家得知为针对盟军的抵抗活动已经就绪，但为我们研发新武器的苏联首席科学家却神秘失踪。
 # translit = wánjiāyǐdexiàjūnxīnchéngyuányǔdáxiàqǔdeliánluò,cóngdáxiànàwánjiādezhīwèizhēnduìméngjūndedǐkànghuódòngyǐjīngjiùxù,dànwèiwǒmenyánfāxīnwǔqìdesūliánshǒuxíkēxuéjiāquèshénmìshīzōng.
 1	玩家	玩家	NOUN	NN	_	9	nsubj	_	SpaceAfter=No|Translit=wánjiā|LTranslit=wánjiā
@@ -10977,6 +11351,7 @@
 40	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s375
+# parallel_id = zhgsd/dev375
 # text = 所以，在现在的图形使用者介面的操作系统中，通常都保留着可选的命令列介面。
 # translit = suǒyǐ,zàixiànzàidetúxíngshǐyòngzhějièmiàndecāozuòxìtǒngzhōng,tōngchángdōubǎoliúzhekěxuǎndemìnglìnglièjièmiàn.
 1	所以	所以	SCONJ	RB	_	17	mark	_	SpaceAfter=No|Translit=suǒyǐ|LTranslit=suǒyǐ
@@ -11006,6 +11381,7 @@
 25	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s376
+# parallel_id = zhgsd/dev376
 # text = 但在西元2000年以后，传媒尺度大开，许多命理节目风行，如：开运鉴定团、命运好好玩，造成命理的风行与正当化。
 # translit = dànzàixiyuán2000niányǐhòu,chuánméichǐdùdàkāi,xǔduōmìnglǐjiémùfēngxíng,rú:kāiyùnjiàndìngtuán,mìngyùnhǎohǎowán,zàochéngmìnglǐdefēngxíngyǔzhèngdānghuà.
 1	但	但	SCONJ	RB	_	15	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -11044,6 +11420,7 @@
 34	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s377
+# parallel_id = zhgsd/dev377
 # text = 命理师是台湾对于算命先生、半仙用现代自创词汇来称呼，是利用中国术数来算命的古老职业。
 # translit = mìnglǐshīshìtáiwānduìyúsuànmìngxiānshēng,bànxianyòngxiàndàizìchuàngcíhuìláichēnghū,shìlìyòngzhōngguóshùshùláisuànmìngdegǔlǎozhíyè.
 1	命理	命理	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=mìnglǐ|LTranslit=mìnglǐ
@@ -11075,6 +11452,7 @@
 27	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s378
+# parallel_id = zhgsd/dev378
 # text = 乡村柏油路纵横交织，程式控制电话遍布全乡。
 # translit = xiāngcūnbǎiyóulùzònghéngjiāozhī,chéngshìkòngzhìdiànhuàbiànbùquánxiāng.
 1	乡村	乡村	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=xiāngcūn|LTranslit=xiāngcūn
@@ -11091,6 +11469,7 @@
 12	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s379
+# parallel_id = zhgsd/dev379
 # text = 他们不分战争的社会根源，认为通过和平谈判和协商就能解决双方的暴力。
 # translit = tāmenbùfēnzhànzhēngdeshèhuìgēnyuán,rènwèitōngguòhépíngtánpànhéxiéshāngjiùnéngjiějuéshuāngfāngdebàolì.
 1	他们	他	PRON	PRP	Number=Plur|Person=3	8	nsubj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -11116,6 +11495,7 @@
 21	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s380
+# parallel_id = zhgsd/dev380
 # text = 香港主权移交后，官方每日的升降旗仪式改于金紫荆广场举行，由香港警察仪仗队执行。
 # translit = xiānggǎngzhǔquányíjiāohòu,guānfāngměirìdeshēngjiàngqíyíshìgǎiyújīnzǐ荆guǎngchǎngjǔxíng,yóuxiānggǎngjǐngcháyízhàngduìzhíxíng.
 1	香港	香港	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=xiānggǎng|LTranslit=xiānggǎng
@@ -11143,6 +11523,7 @@
 23	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s381
+# parallel_id = zhgsd/dev381
 # text = 而她温柔善良的个性也与和缓翁主恰好相反，比起这个同母的妹妹，她与弟弟庄献世子感情也可以说非常融洽。
 # translit = 'értāwēnróushànliángdegèxìngyěyǔhéhuǎnwēngzhǔqiàhǎoxiāngfǎn,bǐqǐzhègètóngmǔdemèimèi,tāyǔdìdìzhuāngxiànshìzigǎnqíngyěkěyǐshuōfēichángróng洽.
 1	而	而	SCONJ	RB	_	12	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -11179,6 +11560,7 @@
 32	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s382
+# parallel_id = zhgsd/dev382
 # text = 和黄是业务遍布全球的大型跨国企业，经营多元化业务，包括全球多个市场最大的货柜码头经营商、零售连锁集团、地产发展与基建业务，以至电讯及电台广播服务。
 # translit = héhuángshìyèwubiànbùquánqiúdedàxíngkuàguóqǐyè,jīngyíngduōyuánhuàyèwu,bāokuòquánqiúduōgèshìchǎngzuìdàdehuòguìmǎtóujīngyíngshāng,língshòuliánsuǒjítuán,dechǎnfāzhǎnyǔjījiànyèwu,yǐzhìdiànxùnjídiàntáiguǎngbōfúwu.
 1	和黄	和黄	PROPN	NNP	_	11	nsubj	_	SpaceAfter=No|Translit=héhuáng|LTranslit=héhuáng
@@ -11228,6 +11610,7 @@
 45	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s383
+# parallel_id = zhgsd/dev383
 # text = 狐狸因过度疼痛，昏死过去。
 # translit = húliyīnguòdùténgtòng,hūnsǐguòqù.
 1	狐狸	狐狸	NOUN	NN	_	6	nsubj	_	SpaceAfter=No|Translit=húli|LTranslit=húli
@@ -11240,6 +11623,7 @@
 8	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s384
+# parallel_id = zhgsd/dev384
 # text = 以下是一些常见的咖啡种类：咖啡粉的好坏对接下来的烹制过程有非常重要的影响。
 # translit = yǐxiàshìyīxiēchángjiàndekāfēizhǒnglèi:kāfēifěndehǎohuàiduìjiēxiàláide烹zhìguòchéngyǒufēichángzhòngyàodeyǐngxiǎng.
 1	以下	以下	DET	DT	_	7	nsubj	_	SpaceAfter=No|Translit=yǐxià|LTranslit=yǐxià
@@ -11268,6 +11652,7 @@
 24	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s385
+# parallel_id = zhgsd/dev385
 # text = 咖啡因是一种黄嘌呤生物碱化合物，对人类来说是一种兴奋剂。
 # translit = kāfēiyīnshìyīzhǒnghuáng嘌呤shēngwùjiǎnhuàhéwù,duìrénlèiláishuōshìyīzhǒngxìngfènjì.
 1	咖啡	咖啡	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=kāfēi|LTranslit=kāfēi
@@ -11293,6 +11678,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s386
+# parallel_id = zhgsd/dev386
 # text = 深焙咖啡一般比浅焙咖啡的咖啡因含量少，因为烘焙能减少咖啡豆里的咖啡因含量。
 # translit = shēn焙kāfēiyībānbǐqiǎn焙kāfēidekāfēiyīnhánliàngshǎo,yīnwèihōng焙néngjiǎnshǎokāfēidòulǐdekāfēiyīnhánliàng.
 1	深焙	深焙	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=shēn焙|LTranslit=shēn焙
@@ -11321,6 +11707,7 @@
 24	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s387
+# parallel_id = zhgsd/dev387
 # text = 咸昌里，是台湾南部自清治时期至日治初期的一个行政区划，其范围即今屏东县的车城乡北部。
 # translit = xián昌lǐ,shìtáiwānnánbùzìqīngzhìshíqīzhìrìzhìchūqīdeyīgèxíngzhèngqūhuà,qífànwéijíjīnpíngdōngxiàndechēchéngxiāngběibù.
 1	咸昌	咸昌	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=xián昌|LTranslit=xián昌
@@ -11356,6 +11743,7 @@
 31	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s388
+# parallel_id = zhgsd/dev388
 # text = 中华民国时期，咸福宫曾作为故宫博物院乾隆御赏物陈列室。
 # translit = zhōnghuámínguóshíqī,xiánfúgōngcéngzuòwèigùgōngbówùyuàn乾lóngyùshǎngwùchénlièshì.
 1	中华	中华	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=zhōnghuá|LTranslit=zhōnghuá
@@ -11378,6 +11766,7 @@
 18	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s389
+# parallel_id = zhgsd/dev389
 # text = 品客除了口味多样之外，还有限定贩卖地区或时间的特色口味，相当受到消费者的欢迎，而该广告亦于无线、亚视及商台播出。
 # translit = pǐnkèchúlekǒuwèiduōyàngzhīwài,háiyǒuxiàndìngfànmàideqūhuòshíjiāndetèsèkǒuwèi,xiāngdāngshòudàoxiāofèizhědehuanyíng,'érgāiguǎnggàoyìyúwúxiàn,yàshìjíshāngtáibōchū.
 1	品客	品客	PROPN	NNP	_	20	nsubj	_	SpaceAfter=No|Translit=pǐnkè|LTranslit=pǐnkè
@@ -11419,6 +11808,7 @@
 37	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s390
+# parallel_id = zhgsd/dev390
 # text = 哈公，香港作家、电影编导、传媒工作者，原名许国、许子宾，潮汕人，一说是闽南泉州人（潮州话和泉州话都属于闽南语系，和泉州话有很多完全相同，比如“你”、“鱼”、“举”、“话”、“同”等字音）。
 # translit = hāgōng,xiānggǎngzuòjiā,diànyǐngbiāndǎo,chuánméigōngzuòzhě,yuánmíngxǔguó,xǔzibīn,cháo汕rén,yīshuōshì闽nánquánzhōurén(cháozhōuhuàhéquánzhōuhuàdōushǔyú闽nányǔxì,héquánzhōuhuàyǒuhěnduōwánquánxiāngtóng,bǐrú“nǐ”,“yú”,“jǔ”,“huà”,“tóng”děngzìyīn).
 1	哈公	哈公	PROPN	NNP	_	13	nmod	_	SpaceAfter=No|Translit=hāgōng|LTranslit=hāgōng
@@ -11495,6 +11885,7 @@
 72	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s391
+# parallel_id = zhgsd/dev391
 # text = 后来卡通造型的桑德斯上校（由演员Randy Quaid配音），出现在越来越多的肯德基广告中。
 # translit = hòuláikǎtōngzàoxíngdesāngdésīshàngxiào(yóuyǎnyuánRandy Quaidpèiyīn),chūxiànzàiyuèláiyuèduōdekěndéjīguǎnggàozhōng.
 1	后来	后来	NOUN	NN	_	15	nmod:tmod	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -11522,6 +11913,7 @@
 23	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s392
+# parallel_id = zhgsd/dev392
 # text = 因相当着迷小丑，而开始分析和研究有关他的事，还疯狂地爱上他。
 # translit = yīnxiāngdāngzhemíxiǎochǒu,'érkāishǐfēnxīhéyánjiūyǒuguāntādeshì,háifēngkuángde'àishàngtā.
 1	因	因	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=yīn|LTranslit=yīn
@@ -11547,6 +11939,7 @@
 21	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s393
+# parallel_id = zhgsd/dev393
 # text = 圣诞晚会上，哈利、罗恩、赫敏分别提出或接受了异性的邀请，与舞伴一起参与了晚会。
 # translit = shèngdànwǎnhuìshàng,hālì,luō'ēn,hèmǐnfēnbiétíchūhuòjiēshòuleyìxìngdeyāoqǐng,yǔwǔbànyīqǐcānyǔlewǎnhuì.
 1	圣	圣	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=shèng|LTranslit=shèng
@@ -11577,6 +11970,7 @@
 26	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s394
+# parallel_id = zhgsd/dev394
 # text = 最近的公交车站为九三五厂站。
 # translit = zuìjìndegōngjiāochēzhànwèijiǔsānwǔchǎngzhàn.
 1	最近	最近	ADJ	JJ	_	4	amod	_	SpaceAfter=No|Translit=zuìjìn|LTranslit=zuìjìn
@@ -11590,6 +11984,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s395
+# parallel_id = zhgsd/dev395
 # text = 2011年，哈尔滨实现地区生产总值4243.4亿元，比上年增长12.3%，连续9年保持12%以上的增长速度。
 # translit = 2011nián,hā'ěrbīnshíxiàndeqūshēngchǎnzǒngzhí4243.4yìyuán,bǐshàngniánzēngzhǎng12.3%,liánxù9niánbǎochí12%yǐshàngdezēngzhǎngsùdù.
 1	2011	2011	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2011|LTranslit=2011
@@ -11620,6 +12015,7 @@
 26	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s396
+# parallel_id = zhgsd/dev396
 # text = 其中哈尔滨电机厂产品占全国水电工程设备数量的二分之一，火电工程设备数量的三分之一，总量的二分之一，也是三峡工程设备供应国内唯一中标单位，成为同行业龙头。
 # translit = qízhōnghā'ěrbīndiànjīchǎngchǎnpǐnzhànquánguóshuǐdiàngōngchéngshèbèishùliàngde'èrfēnzhīyī,huǒdiàngōngchéngshèbèishùliàngdesānfēnzhīyī,zǒngliàngde'èrfēnzhīyī,yěshìsānxiágōngchéngshèbèigōngyīngguónèiwéiyīzhōngbiāodānwèi,chéngwèitóngxíngyèlóngtóu.
 1	其中	其中	NOUN	NN	_	5	nmod	_	SpaceAfter=No|Translit=qízhōng|LTranslit=qízhōng
@@ -11666,6 +12062,7 @@
 42	。	。	PUNCT	.	_	37	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s397
+# parallel_id = zhgsd/dev397
 # text = 哈尔滨正处于金融业加速期，其金融业的“利基市场”成为国内外银行纷纷锁定的一块肥硕蛋糕。
 # translit = hā'ěrbīnzhèngchùyújīnróngyèjiāsùqī,qíjīnróngyède“lìjīshìchǎng”chéngwèiguónèiwàiyínxíngfēnfēnsuǒdìngdeyīkuàiféi硕dàngāo.
 1	哈尔滨	哈尔滨	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit=hā'ěrbīn|LTranslit=hā'ěrbīn
@@ -11699,6 +12096,7 @@
 29	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s398
+# parallel_id = zhgsd/dev398
 # text = 哈德逊（Hudson，Ohio）是美国俄亥俄州萨米特县的一个城市。
 # translit = hādéxùn(Hudson,Ohio)shìměiguó'é亥'ézhōusàmǐtèxiàndeyīgèchéngshì.
 1	哈德逊	哈德逊	PROPN	NNP	_	16	nsubj	_	SpaceAfter=No|Translit=hādéxùn|LTranslit=hādéxùn
@@ -11720,6 +12118,7 @@
 17	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s399
+# parallel_id = zhgsd/dev399
 # text = 日本品牌的商品，无论是否在日本制造，在台湾通常价格较高但被视为品质较佳，依然有不少人购买。
 # translit = rìběnpǐnpáideshāngpǐn,wúlùnshìfǒuzàirìběnzhìzào,zàitáiwāntōngchángjiàgéjiàogāodànbèishìwèipǐnzhìjiàojiā,yīrányǒubùshǎoréngòumǎi.
 1	日本	日本	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=rìběn|LTranslit=rìběn
@@ -11753,6 +12152,7 @@
 29	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s400
+# parallel_id = zhgsd/dev400
 # text = 2001年5月，经组织批准，哈旺罗布享受正厅级职务工资和医疗待遇，提前退休。
 # translit = 2001nián5yuè,jīngzǔzhīpīzhǔn,hāwàngluōbùxiǎngshòuzhèngtīngjízhíwugōngzīhéyīliáodàiyù,tíqiántuìxiū.
 1	2001	2001	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=2001|LTranslit=2001
@@ -11779,6 +12179,7 @@
 22	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s401
+# parallel_id = zhgsd/dev401
 # text = 他是瑞士著名穆斯林学者塔里克·拉马丹的外祖父，也是著名埃及美术类兄弟会成员贾麦勒·班纳（Gamal al-Banna）的哥哥。
 # translit = tāshìruìshìzhemíngmùsīlínxuézhětǎlǐkè·lāmǎdāndewàizǔfù,yěshìzhemíng'āijíměishùlèixiōngdìhuìchéngyuán贾màilēi·bānnà(Gamal al-Banna)degēgē.
 1	他	他	PRON	PRP	Person=3	29	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -11813,6 +12214,7 @@
 30	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s402
+# parallel_id = zhgsd/dev402
 # text = 保亚沙合共为黑池上阵20场及射入1球，虽然球队透过附加赛取得升班英超资格，但他仍于季后约满被放弃。
 # translit = bǎoyàshāhégòngwèihēichíshàngzhèn20chǎngjíshèrù1qiú,suīránqiúduìtòuguòfùjiāsàiqǔdeshēngbānyīngchāozīgé,dàntāréngyújìhòuyuēmǎnbèifàngqì.
 1	保亚沙	保亚沙	PROPN	NNP	_	5	nsubj	_	SpaceAfter=No|Translit=bǎoyàshā|LTranslit=bǎoyàshā
@@ -11848,6 +12250,7 @@
 31	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s403
+# parallel_id = zhgsd/dev403
 # text = 而在公众场合故意焚烧、毁损、涂划、沾污、践踏市旗、市徽的，由公安部门处以100至500元人民币罚款。
 # translit = 'érzàigōngzhòngchǎnghégùyì焚shāo,huǐsǔn,tuhuà,zhānwū,jiàntàshìqí,shì徽de,yóugōng'ānbùménchùyǐ100zhì500yuánrénmínbìfákuǎn.
 1	而	而	SCONJ	RB	_	20	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -11884,6 +12287,7 @@
 32	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s404
+# parallel_id = zhgsd/dev404
 # text = 俱乐部在2006年将球队名字更名为现在的哈特兰德。
 # translit = jùlèbùzài2006niánjiāngqiúduìmíngzìgèngmíngwèixiànzàidehātèlándé.
 1	俱乐部	俱乐部	NOUN	NN	_	8	nsubj	_	SpaceAfter=No|Translit=jùlèbù|LTranslit=jùlèbù
@@ -11901,6 +12305,7 @@
 13	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s405
+# parallel_id = zhgsd/dev405
 # text = 目前至少有1000名哈瑞迪自愿入伍。
 # translit = mùqiánzhìshǎoyǒu1000mínghāruìdízìyuànrùwu.
 1	目前	目前	NOUN	NN	_	3	nmod:tmod	_	SpaceAfter=No|Translit=mùqián|LTranslit=mùqián
@@ -11914,6 +12319,7 @@
 9	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s406
+# parallel_id = zhgsd/dev406
 # text = 自14岁起，许多哈瑞迪男孩便不再学习任何世俗的科目（科学、数学、外语），转而专注在犹太律法的研读。
 # translit = zì14suìqǐ,xǔduōhāruìdínánháibiànbùzàixuéxírènhéshìsúdekēmù(kēxué,shùxué,wàiyǔ),zhuǎn'érzhuānzhùzàiyóutàilǜfǎdeyándú.
 1	自	自	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zì|LTranslit=zì
@@ -11951,6 +12357,7 @@
 33	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s407
+# parallel_id = zhgsd/dev407
 # text = 该处为一个小型遗址，大约150米宽，200米长，高度约7米。
 # translit = gāichùwèiyīgèxiǎoxíngyízhǐ,dàyuē150mǐkuān,200mǐzhǎng,gāodùyuē7mǐ.
 1	该处	该处	NOUN	NN	_	15	nsubj	_	SpaceAfter=No|Translit=gāichù|LTranslit=gāichù
@@ -11976,6 +12383,7 @@
 21	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s408
+# parallel_id = zhgsd/dev408
 # text = 在1946年，美国本土发生了数宗残暴的私刑，其中有两名黑人男子和两名黑人妇女在乔治亚州的华尔顿县附近被杀害；另外亦有一名刚从二战战场退役的非洲裔军人遭到虐待，称为艾萨克·伍德沃德事件。
 # translit = zài1946nián,měiguóběntǔfāshēngleshùzōngcánbàodesīxíng,qízhōngyǒuliǎngmínghēirénnánzihéliǎngmínghēirénfùnǚzài乔zhìyàzhōudehuá'ěrdùnxiànfùjìnbèishāhài;lìngwàiyìyǒuyīmínggāngcóng'èrzhànzhànchǎngtuìyìdefēizhōu裔jūnrénzāodào虐dài,chēngwèi'àisàkè·wudéwòdéshìjiàn.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -12039,6 +12447,7 @@
 59	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s409
+# parallel_id = zhgsd/dev409
 # text = 杜鲁门是在罗斯福的身体健康每况愈下时被任命为副总统的，而任职副总统的时间只有82日，因此他们两人没有开展重要的合作。
 # translit = dùlǔménshìzàiluōsīfúdeshēntǐjiànkāngměikuàngyùxiàshíbèirènmìngwèifùzǒngtǒngde,'érrènzhífùzǒngtǒngdeshíjiānzhǐyǒu82rì,yīncǐtāmenliǎngrénméiyǒukāizhǎnzhòngyàodehézuò.
 1	杜鲁门	杜鲁门	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=dùlǔmén|LTranslit=dùlǔmén
@@ -12080,6 +12489,7 @@
 37	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s410
+# parallel_id = zhgsd/dev410
 # text = 然而出乎意料的是，杜鲁门宣誓就任副总统之后数日，即接替罗斯福任总统前的数个月，他公然出席了彭德格斯特的丧礼。
 # translit = rán'érchūhuyìliàodeshì,dùlǔménxuānshìjiùrènfùzǒngtǒngzhīhòushùrì,jíjiētìluōsīfúrènzǒngtǒngqiándeshùgèyuè,tāgōngránchūxíle彭dégésītèdesànglǐ.
 1	然而	然而	SCONJ	RB	_	4	mark	_	SpaceAfter=No|Translit=rán'ér|LTranslit=rán'ér
@@ -12117,6 +12527,7 @@
 33	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s411
+# parallel_id = zhgsd/dev411
 # text = 其枪机是以AK-47的双大形闭锁锁耳枪机为蓝本，并且经过相当的修改使其适用于大威力的反器材步枪上。
 # translit = qíqiāngjīshìyǐAK-47deshuāngdàxíngbìsuǒsuǒ'ěrqiāngjīwèilánběn,bìngqiějīngguòxiāngdāngdexiūgǎishǐqíshìyòngyúdàwēilìdefǎnqìcáibùqiāngshàng.
 1	其	其	PRON	PRP	Person=3	2	nmod	_	SpaceAfter=No|Translit=qí|LTranslit=qí
@@ -12152,6 +12563,7 @@
 31	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s412
+# parallel_id = zhgsd/dev412
 # text = 哥伦比亚比索是哥伦比亚正在流通使用的货币。
 # translit = gēlúnbǐyàbǐsuǒshìgēlúnbǐyàzhèngzàiliútōngshǐyòngdehuòbì.
 1	哥伦比亚	哥伦比亚	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=gēlúnbǐyà|LTranslit=gēlúnbǐyà
@@ -12167,6 +12579,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s413
+# parallel_id = zhgsd/dev413
 # text = 参加哥德堡号建造工作的人大约有100至150人，其中约有80人是不领取任何报酬的自愿者。
 # translit = cānjiāgēdébǎohàojiànzàogōngzuòderéndàyuēyǒu100zhì150rén,qízhōngyuēyǒu80rénshìbùlǐngqǔrènhébàochoudezìyuànzhě.
 1	参加	参加	VERB	VV	_	7	acl:relcl	_	SpaceAfter=No|Translit=cānjiā|LTranslit=cānjiā
@@ -12199,6 +12612,7 @@
 28	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s414
+# parallel_id = zhgsd/dev414
 # text = 这个结果来自于次文化成员多样化的喜好。
 # translit = zhègèjiéguǒláizìyúcìwénhuàchéngyuánduōyànghuàdexǐhǎo.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -12217,6 +12631,7 @@
 14	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s415
+# parallel_id = zhgsd/dev415
 # text = 随着冬季及冰雪的来临渡过塞尼奥河的任何企图是不可能的，第8军团在1944年的行动因而结束。
 # translit = suízhedōngjìjíbīngxuědeláilíndùguòsāiní'àohéderènhéqǐtúshìbùkěnéngde,dì8jūntuánzài1944niándexíngdòngyīn'érjiéshù.
 1	随	随	VERB	VV	_	14	advcl	_	SpaceAfter=No|Translit=suí|LTranslit=suí
@@ -12249,6 +12664,7 @@
 28	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s416
+# parallel_id = zhgsd/dev416
 # text = 他表示一定是有相当数量的猎人聚在一起，才能盖起这样的建筑物。
 # translit = tābiǎoshìyīdìngshìyǒuxiāngdāngshùliàngdelièrénjùzàiyīqǐ,cáinénggàiqǐzhèyàngdejiànzhùwù.
 1	他	他	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -12274,6 +12690,7 @@
 21	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s417
+# parallel_id = zhgsd/dev417
 # text = 科学家亦发现，人在悲痛时流的眼泪和伤风感冒及风沙入眼时流的眼泪，其化学成分是不同的。
 # translit = kēxuéjiāyìfāxiàn,rénzàibēitòngshíliúdeyǎnlèihéshāngfēnggǎnmàojífēngshārùyǎnshíliúdeyǎnlèi,qíhuàxuéchéngfēnshìbùtóngde.
 1	科学	科学	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=kēxué|LTranslit=kēxué
@@ -12308,6 +12725,7 @@
 30	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s418
+# parallel_id = zhgsd/dev418
 # text = 大型的食草哺乳动物，如牛是人类早期农业的重要组成部分，几乎所有的文明的早期农业都依赖于牛等牲畜的使用。
 # translit = dàxíngdeshícǎobǔrǔdòngwù,rúniúshìrénlèizǎoqīnóngyèdezhòngyàozǔchéngbùfēn,jǐhusuǒyǒudewénmíngdezǎoqīnóngyèdōuyīlàiyúniúděngshēngchùdeshǐyòng.
 1	大型	大型	NOUN	NN	_	5	nmod	_	SpaceAfter=No|Translit=dàxíng|LTranslit=dàxíng
@@ -12344,6 +12762,7 @@
 32	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s419
+# parallel_id = zhgsd/dev419
 # text = 宋军在王韶的率领下于该年占领唃厮啰国熙河地区，这迫使唃厮啰国与西夏联合，出兵攻打北宋的河州，杀其守将。
 # translit = 宋jūnzàiwáng韶delǜlǐngxiàyúgāiniánzhànlǐng唃厮啰guó熙hédeqū,zhèpòshǐ唃厮啰guóyǔxixiàliánhé,chūbīnggōngdǎběi宋dehézhōu,shāqíshǒujiāng.
 1	宋	宋	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=宋|LTranslit=宋
@@ -12382,6 +12801,7 @@
 34	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s420
+# parallel_id = zhgsd/dev420
 # text = 从此法国成为欧洲第二个拥有住房抗告权的国家。
 # translit = cóngcǐfǎguóchéngwèi'ōuzhōudì'èrgèyōngyǒuzhùfángkànggàoquándeguójiā.
 1	从此	从此	ADV	RB	_	3	advmod	_	SpaceAfter=No|Translit=cóngcǐ|LTranslit=cóngcǐ
@@ -12400,6 +12820,7 @@
 14	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s421
+# parallel_id = zhgsd/dev421
 # text = 随后，唐开始集结陆海部队准备在649年再一次大规模攻高句丽。
 # translit = suíhòu,tángkāishǐjíjiélùhǎibùduìzhǔnbèizài649niánzàiyīcìdàguīmógōnggāojùlì.
 1	随后	随后	ADV	RB	_	4	advmod	_	SpaceAfter=No|Translit=suíhòu|LTranslit=suíhòu
@@ -12423,6 +12844,7 @@
 19	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s422
+# parallel_id = zhgsd/dev422
 # text = 宦官李辅国奉承肃宗，离间玄宗与肃宗的关系，迫使玄宗软禁于太极宫（西内）甘露殿。
 # translit = 宦guānlifǔguófèngchéngsùzōng,líjiān玄zōngyǔsùzōngdeguānxì,pòshǐ玄zōngruǎnjìnyútàijígōng(xinèi)gānlùdiàn.
 1	宦官	宦官	NOUN	NN	_	14	nsubj	_	SpaceAfter=No|Translit=宦guān|LTranslit=宦guān
@@ -12452,6 +12874,7 @@
 25	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s423
+# parallel_id = zhgsd/dev423
 # text = 玄宗虽然没有发动过像唐太宗、唐高宗朝时那样的大规模的开边军事行动。
 # translit = 玄zōngsuīránméiyǒufādòngguòxiàngtángtàizōng,tánggāozōngcháoshínàyàngdedàguīmódekāibiānjūnshìxíngdòng.
 1	玄宗	玄宗	NOUN	NN	_	3	nsubj	_	SpaceAfter=No|Translit=玄zōng|LTranslit=玄zōng
@@ -12478,6 +12901,7 @@
 22	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s424
+# parallel_id = zhgsd/dev424
 # text = 自此以后，没有人敢再有谏争之言了。
 # translit = zìcǐyǐhòu,méiyǒuréngǎnzàiyǒu谏zhēngzhīyánle.
 1	自	自	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zì|LTranslit=zì
@@ -12496,6 +12920,7 @@
 14	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s425
+# parallel_id = zhgsd/dev425
 # text = 90年代后期他的财务状况和名声出现了通货膨胀。
 # translit = 90niándàihòuqītādecáiwuzhuàngkuànghémíngshēngchūxiànletōnghuòpéngzhàng.
 1	90	90	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=90|LTranslit=90
@@ -12514,6 +12939,7 @@
 14	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s426
+# parallel_id = zhgsd/dev426
 # text = 唐诗咏中学时开始兼职模特儿，直至2000年参演“香港电台”的电视剧《青春@Y2K》同期演员有余文乐、蔡卓妍、黎国辉等。
 # translit = tángshī咏zhōngxuéshíkāishǐjiānzhímótèr,zhízhì2000niáncānyǎn“xiānggǎngdiàntái”dediànshìjù«qīngchūn@Y2K»tóngqīyǎnyuányǒuyúwénlè,蔡卓妍,líguóhuīděng.
 1	唐	唐	PROPN	NNP	_	12	nsubj	_	SpaceAfter=No|Translit=táng|LTranslit=táng
@@ -12555,6 +12981,7 @@
 37	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s427
+# parallel_id = zhgsd/dev427
 # text = 据《淡水厅志》记载：“淡水开垦，自奇里岸（今唭哩岸）始。”
 # translit = jù«dànshuǐtīngzhì»jìzài:“dànshuǐkāikěn,zìqílǐ'àn(jīn唭li'àn)shǐ.”
 1	据	据	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=jù|LTranslit=jù
@@ -12582,6 +13009,7 @@
 23	”	”	PUNCT	''	_	21	punct	_	SpaceAfter=No|Translit=”|LTranslit=”
 
 # sent_id = dev-s428
+# parallel_id = zhgsd/dev428
 # text = 唯心论直接相对于唯物论，后者认为世界的基本成分为物质，我们对世界之认识主要是通过物质，并将之视作为一种物质形式与过程。
 # translit = wéixīnlùnzhíjiēxiāngduìyúwéiwùlùn,hòuzhěrènwèishìjièdejīběnchéngfēnwèiwùzhì,wǒmenduìshìjièzhīrènshizhǔyàoshìtōngguòwùzhì,bìngjiāngzhīshìzuòwèiyīzhǒngwùzhìxíngshìyǔguòchéng.
 1	唯心	唯心	ADJ	JJ	_	2	compound	_	SpaceAfter=No|Translit=wéixīn|LTranslit=wéixīn
@@ -12625,6 +13053,7 @@
 39	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s429
+# parallel_id = zhgsd/dev429
 # text = 投资贷款由贷款人发出，并一直在其资产负债表上体现，直至贷款到期。
 # translit = tóuzī贷kuǎnyóu贷kuǎnrénfāchū,bìngyīzhízàiqízīchǎnfùzhàibiǎoshàngtǐxiàn,zhízhì贷kuǎndàoqī.
 1	投资	投资	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=tóuzī|LTranslit=tóuzī
@@ -12650,6 +13079,7 @@
 21	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s430
+# parallel_id = zhgsd/dev430
 # text = 魏惠王怨恨商鞅用欺骗的手段俘虏公子卬、击败魏军，将其驱逐回秦国。
 # translit = 魏惠wángyuànhènshāng鞅yòngqīpiàndeshǒuduànfúlǔgōngzi卬,jībài魏jūn,jiāngqíqūzhúhuí秦guó.
 1	魏	魏	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=魏|LTranslit=魏
@@ -12677,6 +13107,7 @@
 23	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s431
+# parallel_id = zhgsd/dev431
 # text = 一般来说，同一款间格的单边单位比非单边的呎价约贵20%。
 # translit = yībānláishuō,tóngyīkuǎnjiāngédedānbiāndānwèibǐfēidānbiānde呎jiàyuēguì20%.
 1	一般	一般	ADJ	JJ	_	3	advmod	_	SpaceAfter=No|Translit=yībān|LTranslit=yībān
@@ -12703,6 +13134,7 @@
 22	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s432
+# parallel_id = zhgsd/dev432
 # text = 她最擅长运用魔咒施加于药草，并召唤来神明的力量于自身，将人永远变成猪等动物。
 # translit = tāzuì擅zhǎngyùnyòngmózhòushījiāyúyàocǎo,bìngzhàohuànláishénmíngdelìliàngyúzìshēn,jiāngrényǒngyuǎnbiànchéngzhūděngdòngwù.
 1	她	她	PRON	PRP	Person=3	22	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -12733,6 +13165,7 @@
 26	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s433
+# parallel_id = zhgsd/dev433
 # text = 虽然西克索人只统治埃及的北部，但整个埃及都向他们进贡。
 # translit = suīránxikèsuǒrénzhǐtǒngzhì'āijídeběibù,dànzhěnggè'āijídōuxiàngtāmenjìngòng.
 1	虽然	虽然	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -12754,6 +13187,7 @@
 17	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s434
+# parallel_id = zhgsd/dev434
 # text = 喜市于2003年提供居民范围庞大的无线网路服务，受到全国性的瞩目。
 # translit = xǐshìyú2003niántígōngjūmínfànwéipángdàdewúxiànwǎnglùfúwu,shòudàoquánguóxìngde瞩mù.
 1	喜	喜	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=xǐ|LTranslit=xǐ
@@ -12778,6 +13212,7 @@
 20	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s435
+# parallel_id = zhgsd/dev435
 # text = 在《恶灵古堡》中，植物也可以感染病毒而成为丧尸。
 # translit = zài«'èlínggǔbǎo»zhōng,zhíwùyěkěyǐgǎnrǎnbìngdú'érchéngwèisàngshī.
 1	在	在	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -12799,6 +13234,7 @@
 17	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s436
+# parallel_id = zhgsd/dev436
 # text = 1825年1月28日皮克特生于维吉尼亚州的里奇蒙，1846年于西点军校毕业。
 # translit = 1825nián1yuè28rìpíkètèshēngyúwéijíníyàzhōudelǐqíméng,1846niányúxidiǎnjūnxiàobìyè.
 1	1825	1825	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1825|LTranslit=1825
@@ -12824,6 +13260,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s437
+# parallel_id = zhgsd/dev437
 # text = 皮克特在内战末年一直留在维吉尼亚州。
 # translit = píkètèzàinèizhànmòniányīzhíliúzàiwéijíníyàzhōu.
 1	皮克特	皮克特	PROPN	NNP	_	6	nsubj	_	SpaceAfter=No|Translit=píkètè|LTranslit=píkètè
@@ -12838,6 +13275,7 @@
 10	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s438
+# parallel_id = zhgsd/dev438
 # text = 他也是首位担任公务员的英国王室成员。
 # translit = tāyěshìshǒuwèidānrèngōngwuyuándeyīngguówángshìchéngyuán.
 1	他	他	PRON	PRP	Person=3	10	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -12853,6 +13291,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s439
+# parallel_id = zhgsd/dev439
 # text = 乔治王子和玛丽娜公主的婚姻是英国王室最后一桩门当户对的婚姻。
 # translit = 乔zhìwángzihémǎlì娜gōngzhǔdehūnyīnshìyīngguówángshìzuìhòuyīzhuāngméndānghùduìdehūnyīn.
 1	乔治	乔治	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=乔zhì|LTranslit=乔zhì
@@ -12874,6 +13313,7 @@
 17	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s440
+# parallel_id = zhgsd/dev440
 # text = 玛丽娜公主生于1906年，比乔治王子年幼四岁。
 # translit = mǎlì娜gōngzhǔshēngyú1906nián,bǐ乔zhìwángziniányòusìsuì.
 1	玛丽娜	玛丽娜	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=mǎlì娜|LTranslit=mǎlì娜
@@ -12892,6 +13332,7 @@
 14	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s441
+# parallel_id = zhgsd/dev441
 # text = 直到1934年8月，应玛丽娜公主的姐姐奥尔加公主和姐夫保罗王子的邀请，乔治王子来到南斯拉夫才和玛丽娜公主订婚。
 # translit = zhídào1934nián8yuè,yīngmǎlì娜gōngzhǔdejiejie'ào'ěrjiāgōngzhǔhéjiefubǎoluōwángzideyāoqǐng,乔zhìwángziláidàonánsīlāfucáihémǎlì娜gōngzhǔdìnghūn.
 1	直到	直到	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=zhídào|LTranslit=zhídào
@@ -12926,6 +13367,7 @@
 30	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s442
+# parallel_id = zhgsd/dev442
 # text = 在这之后，他接拍了一部名为《我们是马歇尔》的电影，这部电影讲述的是大学橄榄球队中发生的故事，不过并没有获得霹雳娇娃那样的成功。
 # translit = zàizhèzhīhòu,tājiēpāileyībùmíngwèi«wǒmenshìmǎxiē'ěr»dediànyǐng,zhèbùdiànyǐngjiǎngshùdeshìdàxué橄榄qiúduìzhōngfāshēngdegùshì,bùguòbìngméiyǒuhuòde霹雳jiāowánàyàngdechénggōng.
 1	在	在	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -12974,6 +13416,7 @@
 44	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s443
+# parallel_id = zhgsd/dev443
 # text = 汉密尔顿在当时被视为棒球界的一颗新星。
 # translit = hànmì'ěrdùnzàidāngshíbèishìwèibàngqiújièdeyīkēxīnxīng.
 1	汉密尔顿	汉密尔顿	PROPN	NNP	_	5	nsubj:pass	_	SpaceAfter=No|Translit=hànmì'ěrdùn|LTranslit=hànmì'ěrdùn
@@ -12991,6 +13434,7 @@
 13	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s444
+# parallel_id = zhgsd/dev444
 # text = 在光纤通讯中，单模光纤是一种设计用来传送单一光束（模）的光纤。
 # translit = zàiguāngxiāntōngxùnzhōng,dānmóguāngxiānshìyīzhǒngshèjìyòngláichuánsòngdānyīguāngshù(mó)deguāngxiān.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -13018,6 +13462,7 @@
 23	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s445
+# parallel_id = zhgsd/dev445
 # text = 通常此光束内有多种波长的光。
 # translit = tōngchángcǐguāngshùnèiyǒuduōzhǒngbōzhǎngdeguāng.
 1	通常	通常	ADV	RB	_	5	advmod	_	SpaceAfter=No|Translit=tōngcháng|LTranslit=tōngcháng
@@ -13033,6 +13478,7 @@
 11	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s446
+# parallel_id = zhgsd/dev446
 # text = 大众被邀请参观实验室的设施，目睹实验室有关科学技术的演示。
 # translit = dàzhòngbèiyāoqǐngcānguānshíyànshìdeshèshī,mù睹shíyànshìyǒuguānkēxuéjìshùdeyǎnshì.
 1	大众	大众	NOUN	NN	_	10	nsubj	_	SpaceAfter=No|Translit=dàzhòng|LTranslit=dàzhòng
@@ -13055,6 +13501,7 @@
 18	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s447
+# parallel_id = zhgsd/dev447
 # text = 火箭发动机直到1940年代中期经常被称为喷射发动机。
 # translit = huǒjiànfādòngjīzhídào1940niándàizhōngqījīngchángbèichēngwèipēnshèfādòngjī.
 1	火箭	火箭	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=huǒjiàn|LTranslit=huǒjiàn
@@ -13074,6 +13521,7 @@
 15	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s448
+# parallel_id = zhgsd/dev448
 # text = 1917年，北白川宫成久王与王妃也亲自前往视查。
 # translit = 1917nián,běibáichuāngōngchéngjiǔwángyǔwáng妃yěqīnzìqiánwǎngshìchá.
 1	1917	1917	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1917|LTranslit=1917
@@ -13092,6 +13540,7 @@
 14	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s449
+# parallel_id = zhgsd/dev449
 # text = 1980年由陈宗仁接任，1982年配合嘉义市升格为省辖市，校名为嘉义市立民生国民中学。
 # translit = 1980niányóuchénzōngrénjiērèn,1982niánpèihéjiāyìshìshēnggéwèishěngxiáshì,xiàomíngwèijiāyìshìlìmínshēngguómínzhōngxué.
 1	1980	1980	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1980|LTranslit=1980
@@ -13123,6 +13572,7 @@
 27	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s450
+# parallel_id = zhgsd/dev450
 # text = 嘉莉迪在参加《超级名模生死斗》前是一位摄影师，也曾担任过演员。
 # translit = jiā莉dízàicānjiā«chāojímíngmóshēngsǐdòu»qiánshìyīwèishèyǐngshī,yěcéngdānrènguòyǎnyuán.
 1	嘉莉迪	嘉莉迪	PROPN	NNP	_	19	nsubj	_	SpaceAfter=No|Translit=jiā莉dí|LTranslit=jiā莉dí
@@ -13149,6 +13599,7 @@
 22	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s451
+# parallel_id = zhgsd/dev451
 # text = 40楼为Penthouse，设4个复式单位。
 # translit = 40lóuwèiPenthouse,shè4gèfùshìdānwèi.
 1	40	40	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=40|LTranslit=40
@@ -13164,6 +13615,7 @@
 11	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s452
+# parallel_id = zhgsd/dev452
 # text = 另外，嘉薛地喜爱研究历史，二战前曾发表一些有关香港通商史和商业史的文章。
 # translit = lìngwài,jiā薛dexǐ'àiyánjiūlìshǐ,'èrzhànqiáncéngfābiǎoyīxiēyǒuguānxiānggǎngtōngshāngshǐhéshāngyèshǐdewénzhāng.
 1	另外	另外	ADV	RB	_	11	advmod	_	SpaceAfter=No|Translit=lìngwài|LTranslit=lìngwài
@@ -13190,6 +13642,7 @@
 22	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s453
+# parallel_id = zhgsd/dev453
 # text = 正传《嘉薰医生》最初是作者陈嘉薰运用自身形象进行创作。
 # translit = zhèngchuán«jiā薰yīshēng»zuìchūshìzuòzhěchénjiā薰yùnyòngzìshēnxíngxiàngjìnxíngchuàngzuò.
 1	正传	正传	NOUN	NN	_	7	nsubj	_	SpaceAfter=No|Translit=zhèngchuán|LTranslit=zhèngchuán
@@ -13210,6 +13663,7 @@
 16	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s454
+# parallel_id = zhgsd/dev454
 # text = 学校亦于1956年成立了香港的第一队香港红十字会青年团（Youth Unit One），其后逐渐普及于其他中学，成为香港其中一个最具规模的制服团体。
 # translit = xuéxiàoyìyú1956niánchénglìlexiānggǎngdedìyīduìxiānggǎnghóngshízìhuìqīngniántuán(Youth Unit One),qíhòuzhújiànpǔjíyúqítāzhōngxué,chéngwèixiānggǎngqízhōngyīgèzuìjùguīmódezhìfútuántǐ.
 1	学校	学校	NOUN	NN	_	6	nsubj	_	SpaceAfter=No|Translit=xuéxiào|LTranslit=xuéxiào
@@ -13257,6 +13711,7 @@
 43	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s455
+# parallel_id = zhgsd/dev455
 # text = 深蓝色的背心绒布连身百折裙，配白色恤衫、蓝色的领带和腰带，深蓝色的短袜和黑色皮鞋。
 # translit = shēnlánsèdebèixīnróngbùliánshēnbǎizhéqún,pèibáisè恤shān,lánsèdelǐngdàihéyāodài,shēnlánsèdeduǎnwàhéhēisèpíxié.
 1	深蓝	深蓝	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=shēnlán|LTranslit=shēnlán
@@ -13289,6 +13744,7 @@
 28	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s456
+# parallel_id = zhgsd/dev456
 # text = 2011年1月8日，她在亚利桑那州图森市的Safeway超级市场外举办“国会就在你的街角”（Congress on Your Corner）活动时遭枪手击中头部受重伤，当时被枪手击中的另外还有18人。
 # translit = 2011nián1yuè8rì,tāzàiyàlìsāngnàzhōutúsēnshìdeSafewaychāojíshìchǎngwàijǔbàn“guóhuìjiùzàinǐdejiējiǎo”(Congress on Your Corner)huódòngshízāoqiāngshǒujīzhōngtóubùshòuzhòngshāng,dāngshíbèiqiāngshǒujīzhōngdelìngwàiháiyǒu18rén.
 1	2011	2011	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2011|LTranslit=2011
@@ -13347,6 +13803,7 @@
 54	。	。	PUNCT	.	_	36	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s457
+# parallel_id = zhgsd/dev457
 # text = 她也是该州历史上最年轻的女性参议员。
 # translit = tāyěshìgāizhōulìshǐshàngzuìniánqīngdenǚxìngcānyìyuán.
 1	她	她	PRON	PRP	Person=3	11	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -13363,6 +13820,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s458
+# parallel_id = zhgsd/dev458
 # text = 噶哈巫语对数词的称呼与台湾各原住民族的数词称呼法，或多或少有相似之处。
 # translit = 噶hā巫yǔduìshùcídechēnghūyǔtáiwāngèyuánzhùmínzúdeshùcíchēnghūfǎ,huòduōhuòshǎoyǒuxiāngshìzhīchù.
 1	噶哈巫	噶哈巫	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=噶hā巫|LTranslit=噶hā巫
@@ -13392,6 +13850,7 @@
 25	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s459
+# parallel_id = zhgsd/dev459
 # text = 1745年，准噶尔汗国爆发大瘟疫，五十岁的噶尔丹策零9月在伊犁染病去世。
 # translit = 1745nián,zhǔn噶'ěrhànguóbàofādà瘟yì,wǔshísuìde噶'ěrdāncèlíng9yuèzàiyīlírǎnbìngqùshì.
 1	1745	1745	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1745|LTranslit=1745
@@ -13416,6 +13875,7 @@
 20	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s460
+# parallel_id = zhgsd/dev460
 # text = 而动态性质的名物化以谓语等词加上后缀/-an/等表示，其特性为词语在句中有动态语义（active）连系。
 # translit = 'érdòngtàixìngzhìdemíngwùhuàyǐwèiyǔděngcíjiāshànghòuzhui/-an/děngbiǎoshì,qítèxìngwèicíyǔzàijùzhōngyǒudòngtàiyǔyì(active)liánxì.
 1	而	而	SCONJ	RB	_	17	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -13452,6 +13912,7 @@
 32	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s461
+# parallel_id = zhgsd/dev461
 # text = 萧瑜认为严光拜访光武帝，表明其爱慕虚荣。
 # translit = 萧瑜rènwèiyánguāngbàifǎngguāngwǔdì,biǎomíngqí'àimùxūróng.
 1	萧	萧	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit=萧|LTranslit=萧
@@ -13470,6 +13931,7 @@
 14	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s462
+# parallel_id = zhgsd/dev462
 # text = 因实际持有单位台湾银行对古迹维护方式及见解不同，该古迹连同周边附属建物于1993年后严重荒废。
 # translit = yīnshíjìchíyǒudānwèitáiwānyínxíngduìgǔjīwéihùfāngshìjíjiànjiěbùtóng,gāigǔjīliántóngzhōubiānfùshǔjiànwùyú1993niánhòuyánzhònghuāngfèi.
 1	因	因	ADP	IN	_	13	case	_	SpaceAfter=No|Translit=yīn|LTranslit=yīn
@@ -13501,6 +13963,7 @@
 27	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s463
+# parallel_id = zhgsd/dev463
 # text = 四川北路站周边，目前仍以20世纪建造的石库门住宅和公园绿地为主。
 # translit = sìchuānběilùzhànzhōubiān,mùqiánréngyǐ20shìjìjiànzàodeshíkùménzhùzháihégōngyuánlǜdewèizhǔ.
 1	四川	四川	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=sìchuān|LTranslit=sìchuān
@@ -13526,6 +13989,7 @@
 21	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s464
+# parallel_id = zhgsd/dev464
 # text = 明太祖洪武四年（1371年），四川地区并入明朝版图。
 # translit = míngtàizǔhóngwǔsìnián(1371nián),sìchuāndeqūbìngrùmíngcháobǎntú.
 1	明	明	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=míng|LTranslit=míng
@@ -13546,6 +14010,7 @@
 16	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s465
+# parallel_id = zhgsd/dev465
 # text = 8世纪的鄂尔浑碑铭中有一部分是回纥人刻成的，但其语言和后东突厥汗国时期的碑刻基本一致，称为古突厥语。
 # translit = 8shìjìde鄂'ěrhúnbēi铭zhōngyǒuyībùfēnshìhuí纥rénkèchéngde,dànqíyǔyánhéhòudōngtū厥hànguóshíqīdebēikèjīběnyīzhì,chēngwèigǔtū厥yǔ.
 1	8	8	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=8|LTranslit=8
@@ -13585,6 +14050,7 @@
 35	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s466
+# parallel_id = zhgsd/dev466
 # text = 国际天文联会（IAU）将为该组卫星保留因纽特神话名。
 # translit = guójìtiānwénliánhuì(IAU)jiāngwèigāizǔwèixīngbǎoliúyīnniǔtèshénhuàmíng.
 1	国际	国际	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=guójì|LTranslit=guójì
@@ -13604,6 +14070,7 @@
 15	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s467
+# parallel_id = zhgsd/dev467
 # text = 十公主有别于一般皇室宗女，她从儿时起，便经常跟着皇父与大臣公卿会面，亦常与亲哥哥及堂兄弟们混在一起，因此熟知政务。
 # translit = shígōngzhǔyǒubiéyúyībānhuángshìzōngnǚ,tācóngrshíqǐ,biànjīngchánggēnzhehuángfùyǔdàchéngōng卿huìmiàn,yìchángyǔqīngēgējítángxiōngdìmenhùnzàiyīqǐ,yīncǐshúzhīzhèngwu.
 1	十	十	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=shí|LTranslit=shí
@@ -13648,6 +14115,7 @@
 40	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s468
+# parallel_id = zhgsd/dev468
 # text = 车站距固始县城约30公里，距西安站822公里，距南京站333公里。
 # translit = chēzhànjùgùshǐxiànchéngyuē30gōnglǐ,jùxi'ānzhàn822gōnglǐ,jùnánjīngzhàn333gōnglǐ.
 1	车站	车站	NOUN	NN	_	7	nsubj	_	SpaceAfter=No|Translit=chēzhàn|LTranslit=chēzhàn
@@ -13672,6 +14140,7 @@
 20	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s469
+# parallel_id = zhgsd/dev469
 # text = 国联季后赛在NFC冠军赛两队竞争乔治哈拉斯杯达到高潮。
 # translit = guóliánjìhòusàizàiNFCguānjūnsàiliǎngduìjìngzhēng乔zhìhālāsībēidádàogāocháo.
 1	国联	国联	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=guólián|LTranslit=guólián
@@ -13691,6 +14160,7 @@
 15	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s470
+# parallel_id = zhgsd/dev470
 # text = 1993年，该馆文物库房迁到柏林寺藏经楼。
 # translit = 1993nián,gāiguǎnwénwùkùfángqiāndàobǎilínsìcángjīnglóu.
 1	1993	1993	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1993|LTranslit=1993
@@ -13707,6 +14177,7 @@
 12	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s471
+# parallel_id = zhgsd/dev471
 # text = 国际友谊博物馆是中华人民共和国国家文物局直属的国家级博物馆，“专门收藏、保护、研究和展示新中国对外交往中党和国家领导人受赠的外交礼品”。
 # translit = guójìyouyìbówùguǎnshìzhōnghuárénmíngònghéguóguójiāwénwùjúzhíshǔdeguójiājíbówùguǎn,“zhuānménshōucáng,bǎohù,yánjiūhézhǎnshìxīnzhōngguóduìwàijiāowǎngzhōngdǎnghéguójiālǐngdǎorénshòu赠dewàijiāolǐpǐn”.
 1	国际	国际	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=guójì|LTranslit=guójì
@@ -13755,6 +14226,7 @@
 44	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s472
+# parallel_id = zhgsd/dev472
 # text = 此外还作为国际奥委会的代表进行技术监督，组织四年一度的世界射击锦标赛；促进和发展教学计划与方法、出版联合会通讯和奖励对国际射联有突出贡献的个人。
 # translit = cǐwàiháizuòwèiguójì'àowěihuìdedàibiǎojìnxíngjìshùjiāndū,zǔzhīsìniányīdùdeshìjièshèjījǐnbiāosài;cùjìnhéfāzhǎnjiàoxuéjìhuàyǔfāngfǎ,chūbǎnliánhéhuìtōngxùnhéjiǎnglìduìguójìshèliányǒutūchūgòngxiàndegèrén.
 1	此外	此外	NOUN	NN	_	25	obl	_	SpaceAfter=No|Translit=cǐwài|LTranslit=cǐwài
@@ -13806,6 +14278,7 @@
 47	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s473
+# parallel_id = zhgsd/dev473
 # text = 国际气象节的发起人是一个法国人。
 # translit = guójìqìxiàngjiédefāqǐrénshìyīgèfǎguórén.
 1	国际	国际	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=guójì|LTranslit=guójì
@@ -13822,6 +14295,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s474
+# parallel_id = zhgsd/dev474
 # text = 各国不论政治、经济、社会制度上有何差异，都有义务互相协助。
 # translit = gèguóbùlùnzhèngzhì,jīngjì,shèhuìzhìdùshàngyǒuhéchàyì,dōuyǒuyìwuhùxiāngxiézhù.
 1	各国	各国	NOUN	NN	_	18	nsubj	_	SpaceAfter=No|Translit=gèguó|LTranslit=gèguó
@@ -13845,6 +14319,7 @@
 19	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s475
+# parallel_id = zhgsd/dev475
 # text = 国家有权对其在国外的本国国民的合法权益进行保护，这是国家属人优越权的重要内容之一。
 # translit = guójiāyǒuquánduìqízàiguówàideběnguóguómíndehéfǎquányìjìnxíngbǎohù,zhèshìguójiāshǔrényōuyuèquándezhòngyàonèiróngzhīyī.
 1	国家	国家	NOUN	NN	_	13	nsubj	_	SpaceAfter=No|Translit=guójiā|LTranslit=guójiā
@@ -13876,6 +14351,7 @@
 27	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s476
+# parallel_id = zhgsd/dev476
 # text = 追求利润的动机不断推动着一般国际法的向前发展和海商法的形成。
 # translit = zhuīqiúlìrùndedòngjībùduàntuīdòngzheyībānguójìfǎdexiàngqiánfāzhǎnhéhǎishāngfǎdexíngchéng.
 1	追求	追求	VERB	VV	_	4	acl:relcl	_	SpaceAfter=No|Translit=zhuīqiú|LTranslit=zhuīqiú
@@ -13900,6 +14376,7 @@
 20	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s477
+# parallel_id = zhgsd/dev477
 # text = 该机构的宗旨为“致力于推动电磁理论及其相关的先进应用，以及在全球范围促进电磁学的教育和学术交流。”
 # translit = gāijīgòudezōng旨wèi“zhìlìyútuīdòngdiàncílǐlùnjíqíxiāngguāndexiānjìnyīngyòng,yǐjízàiquánqiúfànwéicùjìndiàncíxuédejiàoyùhéxuéshùjiāoliú.”
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -13936,6 +14413,7 @@
 32	”	”	PUNCT	''	_	7	punct	_	SpaceAfter=No|Translit=”|LTranslit=”
 
 # sent_id = dev-s478
+# parallel_id = zhgsd/dev478
 # text = 这场战役于1553年12月25日发生在智利图卡佩尔。
 # translit = zhèchǎngzhànyìyú1553nián12yuè25rìfāshēngzàizhìlìtúkǎpèi'ěr.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -13955,6 +14433,7 @@
 15	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s479
+# parallel_id = zhgsd/dev479
 # text = 在南部环礁的一个灯塔小岛上居住着大量海鸟。
 # translit = zàinánbùhuán礁deyīgèdēngtǎxiǎodǎoshàngjūzhùzhedàliànghǎiniǎo.
 1	在	在	VERB	VV	_	10	advcl	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -13973,6 +14452,7 @@
 14	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s480
+# parallel_id = zhgsd/dev480
 # text = 紧随其后，他们研发了喷气动力的Tu-16轰炸机（北大西洋公约组织命名：獾Badger）。
 # translit = jǐnsuíqíhòu,tāmenyánfālepēnqìdònglìdeTu-16hōngzhàjī(běidàxiyánggōngyuēzǔzhīmìngmíng:獾Badger).
 1	紧随	紧随	VERB	VV	_	5	advcl	_	SpaceAfter=No|Translit=jǐnsuí|LTranslit=jǐnsuí
@@ -14001,6 +14481,7 @@
 24	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s481
+# parallel_id = zhgsd/dev481
 # text = 最初总统只是象征式的国家元首，政务由国会主持。
 # translit = zuìchūzǒngtǒngzhǐshìxiàngzhēngshìdeguójiāyuánshǒu,zhèngwuyóuguóhuìzhǔchí.
 1	最初	最初	NOUN	NN	_	9	nmod:tmod	_	SpaceAfter=No|Translit=zuìchū|LTranslit=zuìchū
@@ -14020,6 +14501,7 @@
 15	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s482
+# parallel_id = zhgsd/dev482
 # text = 虽然大部分的总统由民主方法选出，也有部分国家元首是发动政变或起义夺权而产生（如古巴前国务委员会主席菲德尔·卡斯特罗）。
 # translit = suīrándàbùfēndezǒngtǒngyóumínzhǔfāngfǎxuǎnchū,yěyǒubùfēnguójiāyuánshǒushìfādòngzhèngbiànhuòqǐyìduóquán'érchǎnshēng(rúgǔbaqiánguówuwěiyuánhuìzhǔxífēidé'ěr·kǎsītèluō).
 1	虽然	虽然	ADP	IN	_	6	case	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -14060,6 +14542,7 @@
 36	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s483
+# parallel_id = zhgsd/dev483
 # text = 2010年1月12日海地地震中三层中较高的两层倒塌。
 # translit = 2010nián1yuè12rìhǎidedezhènzhōngsāncéngzhōngjiàogāodeliǎngcéngdàotā.
 1	2010	2010	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2010|LTranslit=2010
@@ -14082,6 +14565,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s484
+# parallel_id = zhgsd/dev484
 # text = 于2004年12月，国家应变计划正式生效。
 # translit = yú2004nián12yuè,guójiāyīngbiànjìhuàzhèngshìshēngxiào.
 1	于	于	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=yú|LTranslit=yú
@@ -14098,6 +14582,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s485
+# parallel_id = zhgsd/dev485
 # text = 国家足球博物馆（The National Football Museum）是英国的一座博物馆。
 # translit = guójiāzúqiúbówùguǎn(The National Football Museum)shìyīngguódeyīzuòbówùguǎn.
 1	国家	国家	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=guójiā|LTranslit=guójiā
@@ -14120,6 +14605,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s486
+# parallel_id = zhgsd/dev486
 # text = 74军成军不久随即参与1937年8月13日爆发之淞沪会战，51师在罗店、58师在蕴藻滨战场，随后因损失过重于11月9日撤出淞沪战场休整。
 # translit = 74jūnchéngjūnbùjiǔsuíjícānyǔ1937nián8yuè13rìbàofāzhī淞沪huìzhàn,51shīzàiluōdiàn,58shīzàiyùn藻bīnzhànchǎng,suíhòuyīnsǔnshīguòzhòngyú11yuè9rìchèchū淞沪zhànchǎngxiūzhěng.
 1	74	74	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=74|LTranslit=74
@@ -14168,6 +14654,7 @@
 44	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s487
+# parallel_id = zhgsd/dev487
 # text = 1941年12月日军偷袭珍珠港，随后进攻缅甸，企图切断中国唯一对外之陆上补给线。
 # translit = 1941nián12yuèrìjūntōuxízhēnzhūgǎng,suíhòujìngōng缅diān,qǐtúqièduànzhōngguówéiyīduìwàizhīlùshàngbǔgěixiàn.
 1	1941	1941	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1941|LTranslit=1941
@@ -14196,6 +14683,7 @@
 24	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s488
+# parallel_id = zhgsd/dev488
 # text = 第五军军长杜聿明后在史迪威压力下兼任远征军代理司令长官。
 # translit = dìwǔjūnjūnzhǎngdù聿mínghòuzàishǐdíwēiyālìxiàjiānrènyuǎnzhēngjūndàilǐsīlìngzhǎngguān.
 1	第五	第五	NUM	CD	NumType=Ord	2	nummod	_	SpaceAfter=No|Translit=dìwǔ|LTranslit=dìwǔ
@@ -14217,6 +14705,7 @@
 17	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s489
+# parallel_id = zhgsd/dev489
 # text = 此时，该军下辖第33师、第117师及独立第6旅，在苏鲁战区担任敌后战场对日作战和被共产党彭雪枫军偷袭，政府军伤亡惨重。
 # translit = cǐshí,gāijūnxiàxiádì33shī,dì117shījídúlìdì6lǚ,zàisūlǔzhànqūdānrèndíhòuzhànchǎngduìrìzuòzhànhébèigòngchǎndǎng彭xuě枫jūntōuxí,zhèngfǔjūnshāngwángcǎnzhòng.
 1	此时	此时	NOUN	NN	_	23	nmod:tmod	_	SpaceAfter=No|Translit=cǐshí|LTranslit=cǐshí
@@ -14258,6 +14747,7 @@
 37	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s490
+# parallel_id = zhgsd/dev490
 # text = 当时的香港政府后来把香港以南的航线分予国泰经营，以北的则交予国泰唯一本地对手，怡和洋行属下的香港航空经营。
 # translit = dāngshídexiānggǎngzhèngfǔhòuláibǎxiānggǎngyǐnándehángxiànfēnyǔguótàijīngyíng,yǐběidezéjiāoyǔguótàiwéiyīběndeduìshǒu,怡héyángxíngshǔxiàdexiānggǎnghángkōngjīngyíng.
 1	当时	当时	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=dāngshí|LTranslit=dāngshí
@@ -14293,6 +14783,7 @@
 31	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s491
+# parallel_id = zhgsd/dev491
 # text = 1946年11月，国立中央大学迁回南京。
 # translit = 1946nián11yuè,guólìzhōngyāngdàxuéqiānhuínánjīng.
 1	1946	1946	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1946|LTranslit=1946
@@ -14309,6 +14800,7 @@
 12	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s492
+# parallel_id = zhgsd/dev492
 # text = 1949年1月，南京政府的失败已经成为定局，政府机关开始南迁，中大校长周鸿经也奉命迁校。
 # translit = 1949nián1yuè,nánjīngzhèngfǔdeshībàiyǐjīngchéngwèidìngjú,zhèngfǔjīguānkāishǐnánqiān,zhōngdàxiàozhǎngzhōu鸿jīngyěfèngmìngqiānxiào.
 1	1949	1949	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1949|LTranslit=1949
@@ -14340,6 +14832,7 @@
 27	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s493
+# parallel_id = zhgsd/dev493
 # text = 中央人民政府任命潘菽（原南京大学校长）为校长，孙叔平（原南京市文教局长）为第一副校长，李方训（原金陵大学校长）为第二副校长，保留原南大、金大必要职员组织行政机关。
 # translit = zhōngyāngrénmínzhèngfǔrènmìng潘菽(yuánnánjīngdàxuéxiàozhǎng)wèixiàozhǎng,sūnshūpíng(yuánnánjīngshìwénjiàojúzhǎng)wèidìyīfùxiàozhǎng,lifāngxun(yuánjīnlíngdàxuéxiàozhǎng)wèidì'èrfùxiàozhǎng,bǎoliúyuánnándà,jīndàbìyàozhíyuánzǔzhīxíngzhèngjīguān.
 1	中央	中央	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=zhōngyāng|LTranslit=zhōngyāng
@@ -14397,6 +14890,7 @@
 53	。	。	PUNCT	.	_	43	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s494
+# parallel_id = zhgsd/dev494
 # text = 博爱校区的校门目前有两座-北大门、南大门，其中北大门也为博爱校区的主要校门。
 # translit = bó'àixiàoqūdexiàoménmùqiányǒuliǎngzuò-běidàmén,nándàmén,qízhōngběidàményěwèibó'àixiàoqūdezhǔyàoxiàomén.
 1	博爱	博爱	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=bó'ài|LTranslit=bó'ài
@@ -14427,6 +14921,7 @@
 26	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s495
+# parallel_id = zhgsd/dev495
 # text = 目前博爱校区并无餐厅进驻，仅有理发部、外工房，不过周遭有许多小吃店，提供学生饮食的服务。
 # translit = mùqiánbó'àixiàoqūbìngwúcāntīngjìnzhù,jǐnyǒulǐfābù,wàigōngfáng,bùguòzhōuzāoyǒuxǔduōxiǎochīdiàn,tígōngxuéshēngyǐnshídefúwu.
 1	目前	目前	NOUN	NN	_	10	nmod:tmod	_	SpaceAfter=No|Translit=mùqián|LTranslit=mùqián
@@ -14460,6 +14955,7 @@
 29	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s496
+# parallel_id = zhgsd/dev496
 # text = 在这段期间内，有许多球员获选加入国家青年代表队，毕业后也陆续加入各甲组足球队，成为国家代表队的重要来源。
 # translit = zàizhèduànqījiānnèi,yǒuxǔduōqiúyuánhuòxuǎnjiārùguójiāqīngniándàibiǎoduì,bìyèhòuyělùxùjiārùgèjiǎzǔzúqiúduì,chéngwèiguójiādàibiǎoduìdezhòngyàoláiyuán.
 1	在	在	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -14499,6 +14995,7 @@
 35	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s497
+# parallel_id = zhgsd/dev497
 # text = 屏东农业学校与台北帝国大学（台湾大学前身）、师范学院（台湾师大前身）、台中农学院（中兴大学前身）、台南工学院（成功大学前身），时为台湾五大学府
 # translit = píngdōngnóngyèxuéxiàoyǔtáiběidìguódàxué(táiwāndàxuéqiánshēn),shīfànxuéyuàn(táiwānshīdàqiánshēn),táizhōngnóngxuéyuàn(zhōngxìngdàxuéqiánshēn),táinángōngxuéyuàn(chénggōngdàxuéqiánshēn),shíwèitáiwānwǔdàxuéfǔ
 1	屏东	屏东	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=píngdōng|LTranslit=píngdōng
@@ -14548,6 +15045,7 @@
 45	学府	学府	NOUN	NN	_	0	root	_	SpaceAfter=No|Translit=xuéfǔ|LTranslit=xuéfǔ
 
 # sent_id = dev-s498
+# parallel_id = zhgsd/dev498
 # text = 一楼为供学生自习的K书中心，二楼为期刊阅览室，有数部可上网的电脑供师生查阅、列印资料，并设有咖啡机，三楼为普通阅览室，四楼为邻近音乐教室的“红土艺术空间”与美术教室，五楼为演艺厅。
 # translit = yīlóuwèigōngxuéshēngzìxídeKshūzhōngxīn,'èrlóuwèiqīkānyuèlǎnshì,yǒushùbùkěshàngwǎngdediànnǎogōngshīshēngcháyuè,lièyìnzīliào,bìngshèyǒukāfēijī,sānlóuwèipǔtōngyuèlǎnshì,sìlóuwèilínjìnyīnlèjiàoshìde“hóngtǔyìshùkōngjiān”yǔměishùjiàoshì,wǔlóuwèiyǎnyìtīng.
 1	一	一	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=yī|LTranslit=yī
@@ -14618,6 +15116,7 @@
 66	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s499
+# parallel_id = zhgsd/dev499
 # text = 1955年国立清华大学于新竹复校，1965年恢复物理系大学部。
 # translit = 1955niánguólìqīnghuádàxuéyúxīnzhúfùxiào,1965niánhuīfùwùlǐxìdàxuébù.
 1	1955	1955	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1955|LTranslit=1955
@@ -14640,6 +15139,7 @@
 18	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = dev-s500
+# parallel_id = zhgsd/dev500
 # text = 但在规划过程中，是否能有足够的讨论时间与效率，一直饱受争议。
 # translit = dànzàiguīhuàguòchéngzhōng,shìfǒunéngyǒuzúgòudetǎolùnshíjiānyǔxiàolǜ,yīzhíbǎoshòuzhēngyì.
 1	但	但	SCONJ	RB	_	18	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn

--- a/zh_gsdsimp-ud-test.conllu
+++ b/zh_gsdsimp-ud-test.conllu
@@ -1,4 +1,5 @@
 # sent_id = test-s1
+# parallel_id = zhgsd/test1
 # text = 然而，这样的处理也衍生了一些问题。
 # translit = rán'ér,zhèyàngdechùlǐyěyǎnshēngleyīxiēwèntí.
 1	然而	然而	SCONJ	RB	_	7	mark	_	SpaceAfter=No|Translit=rán'ér|LTranslit=rán'ér
@@ -14,6 +15,7 @@
 11	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s2
+# parallel_id = zhgsd/test2
 # text = 自从2004年提出了兴建人文大楼的构想，企业界陆续有人提供捐款。
 # translit = zìcóng2004niántíchūlexìngjiànrénwéndàlóudegòuxiǎng,qǐyèjièlùxùyǒuréntígōngjuānkuǎn.
 1	自从	自从	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=zìcóng|LTranslit=zìcóng
@@ -37,6 +39,7 @@
 19	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s3
+# parallel_id = zhgsd/test3
 # text = 杜鹃花为温带植物，台北虽然在亚热带，但冬季的东北季风却使得杜鹃花在台大宜然自得。
 # translit = dùjuānhuāwèiwēndàizhíwù,táiběisuīránzàiyàrèdài,dàndōngjìdedōngběijìfēngquèshǐdedùjuānhuāzàitáidàyiránzìde.
 1	杜鹃花	杜鹃花	NOUN	NN	_	4	nsubj	_	SpaceAfter=No|Translit=dùjuānhuā|LTranslit=dùjuānhuā
@@ -64,6 +67,7 @@
 23	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s4
+# parallel_id = zhgsd/test4
 # text = 台大医学人文博物馆是一栋两层楼的建筑，沿中山南路与仁爱路成L型。
 # translit = táidàyīxuérénwénbówùguǎnshìyī栋liǎngcénglóudejiànzhù,yánzhōngshānnánlùyǔrén'àilùchéngLxíng.
 1	台大	台大	PROPN	NNP	_	5	nmod	_	SpaceAfter=No|Translit=táidà|LTranslit=táidà
@@ -93,6 +97,7 @@
 25	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s5
+# parallel_id = zhgsd/test5
 # text = 楼顶有天文台，现为天文社使用。
 # translit = lóudǐngyǒutiānwéntái,xiànwèitiānwénshèshǐyòng.
 1	楼顶	楼顶	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=lóudǐng|LTranslit=lóudǐng
@@ -108,6 +113,7 @@
 11	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s6
+# parallel_id = zhgsd/test6
 # text = 国际北极研究中心的主要伙伴是日本和美国，参与会务的还有来自加拿大、中国、丹麦、德国、日本、挪威、俄罗斯、英国和美国的代表。
 # translit = guójìběijíyánjiūzhōngxīndezhǔyàohuǒbànshìrìběnhéměiguó,cānyǔhuìwudeháiyǒuláizìjiānádà,zhōngguó,dānmài,déguó,rìběn,挪wēi,'éluōsī,yīngguóhéměiguódedàibiǎo.
 1	国际	国际	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=guójì|LTranslit=guójì
@@ -151,6 +157,7 @@
 39	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s7
+# parallel_id = zhgsd/test7
 # text = 其中参赛者年龄不可超过18岁（以当年7月1日为准），且必须就读于中学校（Secondary School）。
 # translit = qízhōngcānsàizhěniánlíngbùkěchāoguò18suì(yǐdāngnián7yuè1rìwèizhǔn),qiěbìxūjiùdúyúzhōngxuéxiào(Secondary School).
 1	其中	其中	NOUN	NN	_	6	obl	_	SpaceAfter=No|Translit=qízhōng|LTranslit=qízhōng
@@ -185,6 +192,7 @@
 30	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s8
+# parallel_id = zhgsd/test8
 # text = 同年9月7日，亚奥理事会主席萨巴赫亲王为国际射击中心主持铜像揭幕仪式。
 # translit = tóngnián9yuè7rì,yà'àolǐshìhuìzhǔxísàbahèqīnwángwèiguójìshèjīzhōngxīnzhǔchítóngxiàngjiēmùyíshì.
 1	同年	同年	NOUN	NN	_	5	nmod	_	SpaceAfter=No|Translit=tóngnián|LTranslit=tóngnián
@@ -210,6 +218,7 @@
 21	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s9
+# parallel_id = zhgsd/test9
 # text = 这些电话经交换机处理，使用的媒介包括海底电缆、人造卫星、无线电、光纤及IP电话（VOIP）。
 # translit = zhèxiēdiànhuàjīngjiāohuànjīchùlǐ,shǐyòngdeméijièbāokuòhǎidǐdiàn缆,rénzàowèixīng,wúxiàndiàn,guāngxiānjíIPdiànhuà(VOIP).
 1	这些	这些	DET	DT	_	2	det	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -243,6 +252,7 @@
 29	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s10
+# parallel_id = zhgsd/test10
 # text = 《圆月弯刀》为古龙晚期作品，1976年6月至1978年5月，香港〈武侠春秋〉282至348期断续连载，原名《刀神》，1978年汉麟出版改名《圆月弯刀》。
 # translit = «yuányuèwāndāo»wèigǔlóngwǎnqīzuòpǐn,1976nián6yuèzhì1978nián5yuè,xiānggǎng<wǔ侠chūnqiū>282zhì348qīduànxùliánzài,yuánmíng«dāoshén»,1978niánhàn麟chūbǎngǎimíng«yuányuèwāndāo».
 1	《	《	PUNCT	(	_	5	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -297,6 +307,7 @@
 50	。	。	PUNCT	.	_	32	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s11
+# parallel_id = zhgsd/test11
 # text = 圆齿龙（Globidens）意为“球状牙齿”，是沧龙科的一个属。
 # translit = yuánchǐlóng(Globidens)yìwèi“qiúzhuàngyáchǐ”,shì沧lóngkēdeyīgèshǔ.
 1	圆齿龙	圆齿龙	NOUN	NN	_	18	nsubj	_	SpaceAfter=No|Translit=yuánchǐlóng|LTranslit=yuánchǐlóng
@@ -320,6 +331,7 @@
 19	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s12
+# parallel_id = zhgsd/test12
 # text = 图波列夫设计局在1960年代末期推出图-154客机后，图波列夫便成为社会主义国家民航飞机的主要供应商。
 # translit = túbōlièfushèjìjúzài1960niándàimòqītuīchūtú-154kèjīhòu,túbōlièfubiànchéngwèishèhuìzhǔyìguójiāmínhángfēijīdezhǔyàogōngyīngshāng.
 1	图波列夫	图波列夫	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=túbōlièfu|LTranslit=túbōlièfu
@@ -351,6 +363,7 @@
 27	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s13
+# parallel_id = zhgsd/test13
 # text = 事实上，团购网站的产品原价和购买数量经常被“注水”，而产品和服务的品质则经常“缩水”。
 # translit = shìshíshàng,tuángòuwǎngzhàndechǎnpǐnyuánjiàhégòumǎishùliàngjīngchángbèi“zhùshuǐ”,'érchǎnpǐnhéfúwudepǐnzhìzéjīngcháng“suōshuǐ”.
 1	事实	事实	NOUN	NN	_	15	obl	_	SpaceAfter=No|Translit=shìshí|LTranslit=shìshí
@@ -384,6 +397,7 @@
 29	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s14
+# parallel_id = zhgsd/test14
 # text = 团购网站的主要产品分为家居类、日用品类、旅游优惠、机票、酒店及邮轮等。
 # translit = tuángòuwǎngzhàndezhǔyàochǎnpǐnfēnwèijiājūlèi,rìyòngpǐnlèi,lǚyóuyōu惠,jīpiào,jiǔdiànjíyóulúnděng.
 1	团购	团购	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=tuángòu|LTranslit=tuángòu
@@ -412,6 +426,7 @@
 24	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s15
+# parallel_id = zhgsd/test15
 # text = 可是，魔牛肝菌的菌肉在被切割或撞伤后会变成蓝色的，而这种菌的菌肉无论如何都是白色的，因此透过切割菌肉便能分辨二者。
 # translit = kěshì,móniúgānjūndejūnròuzàibèiqiègēhuòzhuàngshānghòuhuìbiànchénglánsède,'érzhèzhǒngjūndejūnròuwúlùnrúhédōushìbáisède,yīncǐtòuguòqiègējūnròubiànnéngfēnbiàn'èrzhě.
 1	可是	可是	SCONJ	RB	_	13	mark	_	SpaceAfter=No|Translit=kěshì|LTranslit=kěshì
@@ -454,6 +469,7 @@
 38	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s16
+# parallel_id = zhgsd/test16
 # text = 站牌上标示着“浪漫和传奇的入野松原”。
 # translit = zhànpáishàngbiāoshìzhe“làngmànhéchuánqíderùyěsōngyuán”.
 1	站牌	站牌	NOUN	NN	_	3	nsubj	_	SpaceAfter=No|Translit=zhànpái|LTranslit=zhànpái
@@ -470,6 +486,7 @@
 12	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s17
+# parallel_id = zhgsd/test17
 # text = 自然界的土是由岩石经风化、搬运、堆积而形成的。
 # translit = zìránjièdetǔshìyóuyánshíjīngfēnghuà,bānyùn,duījī'érxíngchéngde.
 1	自然	自然	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=zìrán|LTranslit=zìrán
@@ -491,6 +508,7 @@
 17	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s18
+# parallel_id = zhgsd/test18
 # text = 毛泽东早在1949年3月中共七届二中全会的报告中就明确地说：“占国民经济总产值90%的分散的个体的农业经济和手工业经济，是可能和必须谨慎地、逐步地而又积极地引导它们向着现代化和集体化的方向发展的，任其自流的观点是错误的。”
 # translit = máo泽dōngzǎozài1949nián3yuèzhōnggòngqījiè'èrzhōngquánhuìdebàogàozhōngjiùmíngquèdeshuō:“zhànguómínjīngjìzǒngchǎnzhí90%defēnsàndegètǐdenóngyèjīngjìhéshǒugōngyèjīngjì,shìkěnénghébìxūjǐnshènde,zhúbùde'éryòujījídeyǐndǎotāmenxiàngzhexiàndàihuàhéjítǐhuàdefāngxiàngfāzhǎnde,rènqízìliúdeguāndiǎnshìcuòwùde.”
 1	毛	毛	PROPN	NNP	_	19	nsubj	_	SpaceAfter=No|Translit=máo|LTranslit=máo
@@ -569,6 +587,7 @@
 74	”	”	PUNCT	''	_	71	punct	_	SpaceAfter=No|Translit=”|LTranslit=”
 
 # sent_id = test-s19
+# parallel_id = zhgsd/test19
 # text = 它主要分布在表土层或耕层中，深受耕作施肥等人为因素的影响而极不稳定。
 # translit = tāzhǔyàofēnbùzàibiǎotǔcénghuògēngcéngzhōng,shēnshòugēngzuòshīféiděngrénwèiyīnsùdeyǐngxiǎng'érjíbùwěndìng.
 1	它	它	PRON	PRP	Person=3	22	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -596,6 +615,7 @@
 23	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s20
+# parallel_id = zhgsd/test20
 # text = 土壤是重要的自然资源和生产资料，土壤的植物生产能力是衡量土壤资源质量的标志。
 # translit = tǔrǎngshìzhòngyàodezìránzīyuánhéshēngchǎnzīliào,tǔrǎngdezhíwùshēngchǎnnénglìshìhéngliàngtǔrǎngzīyuánzhìliàngdebiāozhì.
 1	土壤	土壤	NOUN	NN	_	6	nsubj	_	SpaceAfter=No|Translit=tǔrǎng|LTranslit=tǔrǎng
@@ -623,6 +643,7 @@
 23	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s21
+# parallel_id = zhgsd/test21
 # text = 一些土星1号仪表组中的部分也被用在土星1B中了。
 # translit = yīxiētǔxīng1hàoyíbiǎozǔzhōngdebùfēnyěbèiyòngzàitǔxīng1Bzhōngle.
 1	一些	一些	ADJ	JJ	_	9	amod	_	SpaceAfter=No|Translit=yīxiē|LTranslit=yīxiē
@@ -645,6 +666,7 @@
 18	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s22
+# parallel_id = zhgsd/test22
 # text = 它在位于亨茨维尔的空间系统中心建造。
 # translit = tāzàiwèiyú亨茨wéi'ěrdekōngjiānxìtǒngzhōngxīnjiànzào.
 1	它	它	PRON	PRP	Person=3	10	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -660,6 +682,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s23
+# parallel_id = zhgsd/test23
 # text = 这个计算机控制了火箭从起飞前一直到抛弃S-IVB推进器的操作过程。
 # translit = zhègèjìsuànjīkòngzhìlehuǒjiàncóngqǐfēiqiányīzhídàopāoqìS-IVBtuījìnqìdecāozuòguòchéng.
 1	这	这	DET	DT	_	2	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -684,6 +707,7 @@
 20	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s24
+# parallel_id = zhgsd/test24
 # text = 2007年7月6日，圣乔治教堂被马来西亚政府列为50个马来西亚国家宝藏之一。
 # translit = 2007nián7yuè6rì,shèng乔zhìjiàotángbèimǎláixiyàzhèngfǔlièwèi50gèmǎláixiyàguójiābǎocángzhīyī.
 1	2007	2007	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2007|LTranslit=2007
@@ -710,6 +734,7 @@
 22	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s25
+# parallel_id = zhgsd/test25
 # text = 圣伯多禄堂（Iglesia de San Pedro）是西班牙南部城市科尔多瓦的一座罗马天主教教堂，供奉圣伯多禄，位于同名的广场上。
 # translit = shèngbóduō禄táng(Iglesia de San Pedro)shìxibānyánánbùchéngshìkē'ěrduōwǎdeyīzuòluōmǎtiānzhǔjiàojiàotáng,gōngfèngshèngbóduō禄,wèiyútóngmíngdeguǎngchǎngshàng.
 1	圣伯多禄	圣伯多禄	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=shèngbóduō禄|LTranslit=shèngbóduō禄
@@ -745,6 +770,7 @@
 31	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s26
+# parallel_id = zhgsd/test26
 # text = 该市镇总面积11.61平方公里，2009年时的人口为323人。
 # translit = gāishìzhènzǒngmiànjī11.61píngfānggōnglǐ,2009niánshíderénkǒuwèi323rén.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -765,6 +791,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s27
+# parallel_id = zhgsd/test27
 # text = 该市镇总面积38.28平方公里，2009年时的人口为696人。
 # translit = gāishìzhènzǒngmiànjī38.28píngfānggōnglǐ,2009niánshíderénkǒuwèi696rén.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -785,6 +812,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s28
+# parallel_id = zhgsd/test28
 # text = 总面积14平方公里，人口268人，人口密度19.1人/平方公里（2009年）。
 # translit = zǒngmiànjī14píngfānggōnglǐ,rénkǒu268rén,rénkǒumìdù19.1rén/píngfānggōnglǐ(2009nián).
 1	总	总	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=zǒng|LTranslit=zǒng
@@ -809,6 +837,7 @@
 20	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s29
+# parallel_id = zhgsd/test29
 # text = 该市镇总面积28.59平方公里，2009年时的人口为617人。
 # translit = gāishìzhènzǒngmiànjī28.59píngfānggōnglǐ,2009niánshíderénkǒuwèi617rén.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -829,6 +858,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s30
+# parallel_id = zhgsd/test30
 # text = 除了在1900年到1950年间人口上升了大约25%，在此后人口一直下降，现在圣奥斯瓦尔德乡的居民总数比2005年还要少大约35%。
 # translit = chúlezài1900niándào1950niánjiānrénkǒushàngshēngledàyuē25%,zàicǐhòurénkǒuyīzhíxiàjiàng,xiànzàishèng'àosīwǎ'ěrdéxiāngdejūmínzǒngshùbǐ2005niánháiyàoshǎodàyuē35%.
 1	除	除	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=chú|LTranslit=chú
@@ -869,6 +899,7 @@
 36	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s31
+# parallel_id = zhgsd/test31
 # text = 2007年，教堂完成了主体大修工程，工程包括内部结构的调整。
 # translit = 2007nián,jiàotángwánchénglezhǔtǐdàxiūgōngchéng,gōngchéngbāokuònèibùjiégòudediàozhěng.
 1	2007	2007	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2007|LTranslit=2007
@@ -890,6 +921,7 @@
 17	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s32
+# parallel_id = zhgsd/test32
 # text = 1907年到1911年，教堂立面改建为目前的巴伐利亚巴洛克式。
 # translit = 1907niándào1911nián,jiàotánglìmiàngǎijiànwèimùqiándebafálìyàbaluòkèshì.
 1	1907	1907	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1907|LTranslit=1907
@@ -910,6 +942,7 @@
 16	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s33
+# parallel_id = zhgsd/test33
 # text = 该市镇总面积16.71平方公里，2009年时的人口为2070人。
 # translit = gāishìzhènzǒngmiànjī16.71píngfānggōnglǐ,2009niánshíderénkǒuwèi2070rén.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -930,6 +963,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s34
+# parallel_id = zhgsd/test34
 # text = 岛屿长度约为11公里，宽度6公里。
 # translit = dǎoyǔzhǎngdùyuēwèi11gōnglǐ,kuāndù6gōnglǐ.
 1	岛屿	岛屿	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=dǎoyǔ|LTranslit=dǎoyǔ
@@ -945,6 +979,7 @@
 11	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s35
+# parallel_id = zhgsd/test35
 # text = 该岛还设有8个网球场和1个环绕安娜费雷拉峰的马术中心。
 # translit = gāidǎoháishèyǒu8gèwǎngqiúchǎnghé1gèhuánrào'ān娜fèiléilāfēngdemǎshùzhōngxīn.
 1	该岛	该岛	NOUN	NN	_	3	nsubj	_	SpaceAfter=No|Translit=gāidǎo|LTranslit=gāidǎo
@@ -966,6 +1001,7 @@
 17	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s36
+# parallel_id = zhgsd/test36
 # text = 翻译时，除使用原文外，参考的考古文献则多以法、德两文记载和教会用的拉丁文。
 # translit = fānyìshí,chúshǐyòngyuánwénwài,cānkǎodekǎogǔwénxiànzéduōyǐfǎ,déliǎngwénjìzàihéjiàohuìyòngdelādīngwén.
 1	翻译	翻译	VERB	VV	_	21	advcl	_	SpaceAfter=No|Translit=fānyì|LTranslit=fānyì
@@ -998,6 +1034,7 @@
 28	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s37
+# parallel_id = zhgsd/test37
 # text = 后来他重回桥梁道路学院教学，并继续他的研究工作。
 # translit = hòuláitāzhònghuíqiáoliángdàolùxuéyuànjiàoxué,bìngjìxùtādeyánjiūgōngzuò.
 1	后来	后来	NOUN	NN	_	10	nmod:tmod	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -1017,6 +1054,7 @@
 15	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s38
+# parallel_id = zhgsd/test38
 # text = 最古老的是安德里亚·皮萨诺的作品，作于1330年到1336年。
 # translit = zuìgǔlǎodeshì'āndélǐyà·písà诺dezuòpǐn,zuòyú1330niándào1336nián.
 1	最	最	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=zuì|LTranslit=zuì
@@ -1039,6 +1077,7 @@
 18	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s39
+# parallel_id = zhgsd/test39
 # text = 该市镇总面积2.92平方公里，2009年时的人口为1097人。
 # translit = gāishìzhènzǒngmiànjī2.92píngfānggōnglǐ,2009niánshíderénkǒuwèi1097rén.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -1059,6 +1098,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s40
+# parallel_id = zhgsd/test40
 # text = 1914年，政府允诺减少在南非对印度人的歧视。
 # translit = 1914nián,zhèngfǔyǔn诺jiǎnshǎozàinánfēiduìyìndùrénde歧shì.
 1	1914	1914	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1914|LTranslit=1914
@@ -1077,6 +1117,7 @@
 14	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s41
+# parallel_id = zhgsd/test41
 # text = 但是甘地更相信尼赫鲁能建立保障印度人民自由的政府。
 # translit = dànshìgāndegèngxiāngxìnníhèlǔnéngjiànlìbǎozhàngyìndùrénmínzìyóudezhèngfǔ.
 1	但是	但是	SCONJ	RB	_	4	mark	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -1095,6 +1136,7 @@
 14	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s42
+# parallel_id = zhgsd/test42
 # text = 在艾哈迈达巴德建立了Sabarmati Ashram（高僧修行所），还有报纸“年轻的印度”（Young India）。
 # translit = zài'àihāmàidábadéjiànlìleSabarmati Ashram(gāo僧xiūxíngsuǒ),háiyǒubàozhǐ“niánqīngdeyìndù”(Young India).
 1	在	在	VERB	VV	_	3	advcl	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -1124,6 +1166,7 @@
 25	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s43
+# parallel_id = zhgsd/test43
 # text = 除了抵制英国产品外，甘地还极力鼓励人们抵制英国学校，法律机构，辞退政府工作，拒绝缴税，抛弃英国给的称号和荣誉。
 # translit = chúledǐzhìyīngguóchǎnpǐnwài,gāndeháijílìgǔlìrénmendǐzhìyīngguóxuéxiào,fǎlǜjīgòu,cítuìzhèngfǔgōngzuò,jùjuéjiǎoshuì,pāoqìyīngguógěidechēnghàohéróngyù.
 1	除	除	VERB	VV	_	11	advcl	_	SpaceAfter=No|Translit=chú|LTranslit=chú
@@ -1162,6 +1205,7 @@
 34	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s44
+# parallel_id = zhgsd/test44
 # text = 1941年，一些反法西斯的社会党和民主党成员再度进入圣马利诺大议会，他们秘密组建了一个反法西斯的政治运动，这个运动越来越严密、壮大，到1943年时已经成为一支可观的政治力量。
 # translit = 1941nián,yīxiēfǎnfǎxisīdeshèhuìdǎnghémínzhǔdǎngchéngyuánzàidùjìnrùshèngmǎlì诺dàyìhuì,tāmenmìmìzǔjiànleyīgèfǎnfǎxisīdezhèngzhìyùndòng,zhègèyùndòngyuèláiyuèyánmì,zhuàngdà,dào1943niánshíyǐjīngchéngwèiyīzhīkěguāndezhèngzhìlìliàng.
 1	1941	1941	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1941|LTranslit=1941
@@ -1219,6 +1263,7 @@
 53	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s45
+# parallel_id = zhgsd/test45
 # text = 国家博物馆和图书馆收藏的文物和书籍转移到山洞里，以为难民腾出住宿空间。
 # translit = guójiābówùguǎnhétúshūguǎnshōucángdewénwùhéshūjízhuǎnyídàoshāndònglǐ,yǐwèinánmínténgchūzhùsùkōngjiān.
 1	国家	国家	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=guójiā|LTranslit=guójiā
@@ -1246,6 +1291,7 @@
 23	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s46
+# parallel_id = zhgsd/test46
 # text = 面对南下的德国大军，圣马利诺共和国再度陷入惊慌之中。
 # translit = miànduìnánxiàdedéguódàjūn,shèngmǎlì诺gònghéguózàidùxiànrùjīnghuāngzhīzhōng.
 1	面对	面对	VERB	VV	_	11	advcl	_	SpaceAfter=No|Translit=miànduì|LTranslit=miànduì
@@ -1264,6 +1310,7 @@
 14	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s47
+# parallel_id = zhgsd/test47
 # text = 圣马洛区辖有9个县，共有63个市镇。
 # translit = shèngmǎluòqūxiáyǒu9gèxiàn,gòngyǒu63gèshìzhèn.
 1	圣马洛	圣马洛	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=shèngmǎluò|LTranslit=shèngmǎluò
@@ -1281,6 +1328,7 @@
 13	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s48
+# parallel_id = zhgsd/test48
 # text = 20世纪后，飞机被发明，航空测绘地图兴起。
 # translit = 20shìjìhòu,fēijībèifāmíng,hángkōngcèhuìdetúxìngqǐ.
 1	20	20	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=20|LTranslit=20
@@ -1298,6 +1346,7 @@
 13	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s49
+# parallel_id = zhgsd/test49
 # text = 但在2006年由于公众反对，这一计划受到搁浅。
 # translit = dànzài2006niányóuyúgōngzhòngfǎnduì,zhèyījìhuàshòudàogēqiǎn.
 1	但	但	SCONJ	RB	_	12	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -1316,6 +1365,7 @@
 14	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s50
+# parallel_id = zhgsd/test50
 # text = 在此之后，地形图集也成为了现代化国家在规划基础设施和矿产探测中的基础国家资源。
 # translit = zàicǐzhīhòu,dexíngtújíyěchéngwèilexiàndàihuàguójiāzàiguīhuàjīchǔshèshīhékuàngchǎntàncèzhōngdejīchǔguójiāzīyuán.
 1	在此	在此	VERB	VV	_	7	advcl	_	SpaceAfter=No|Translit=zàicǐ|LTranslit=zàicǐ
@@ -1345,6 +1395,7 @@
 25	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s51
+# parallel_id = zhgsd/test51
 # text = 换句话说，如果每个标注的点都在100米的高度，这条线代表的就是100米海拔。
 # translit = huànjùhuàshuō,rúguǒměigèbiāozhùdediǎndōuzài100mǐdegāodù,zhètiáoxiàndàibiǎodejiùshì100mǐhǎibá.
 1	换	换	VERB	VV	_	4	advcl	_	SpaceAfter=No|Translit=huàn|LTranslit=huàn
@@ -1376,6 +1427,7 @@
 27	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s52
+# parallel_id = zhgsd/test52
 # text = 滚球的球主要分为两类，一种由金属制，另一种则塑质所造，前者称金属滚球，后者名为塑质滚球，在这两大类中，再有小金属滚球、草滚球、桌掷球（又称沙狐球）。
 # translit = gǔnqiúdeqiúzhǔyàofēnwèiliǎnglèi,yīzhǒngyóujīnshǔzhì,lìngyīzhǒngzésùzhìsuǒzào,qiánzhěchēngjīnshǔgǔnqiú,hòuzhěmíngwèisùzhìgǔnqiú,zàizhèliǎngdàlèizhōng,zàiyǒuxiǎojīnshǔgǔnqiú,cǎogǔnqiú,zhuōzhìqiú(yòuchēngshāhúqiú).
 1	滚球	滚球	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=gǔnqiú|LTranslit=gǔnqiú
@@ -1438,6 +1490,7 @@
 58	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s53
+# parallel_id = zhgsd/test53
 # text = 地湾城遗址，位于中国甘肃省金塔县，为一个省级文物保护单位，类型为古遗址。
 # translit = dewānchéngyízhǐ,wèiyúzhōngguógānsùshěngjīntǎxiàn,wèiyīgèshěngjíwénwùbǎohùdānwèi,lèixíngwèigǔyízhǐ.
 1	地湾	地湾	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=dewān|LTranslit=dewān
@@ -1467,6 +1520,7 @@
 25	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s54
+# parallel_id = zhgsd/test54
 # text = 与其他胰岛素相比较，本品引起夜间低血糖的风险较低，因而可以进行更为积极的剂量调整以实现血糖达标。
 # translit = yǔqítā胰dǎosùxiāngbǐjiào,běnpǐnyǐnqǐyèjiāndīxuètángdefēngxiǎnjiàodī,yīn'érkěyǐjìnxínggèngwèijījídejìliàngdiàozhěngyǐshíxiànxuètángdábiāo.
 1	与	与	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=yǔ|LTranslit=yǔ
@@ -1500,6 +1554,7 @@
 29	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s55
+# parallel_id = zhgsd/test55
 # text = 长期血糖水平控制良好可以降低糖尿病视网膜病变的风险。
 # translit = zhǎngqīxuètángshuǐpíngkòngzhìliánghǎokěyǐjiàngdītángniàobìngshìwǎngmóbìngbiàndefēngxiǎn.
 1	长期	长期	NOUN	NN	_	5	nmod:tmod	_	SpaceAfter=No|Translit=zhǎngqī|LTranslit=zhǎngqī
@@ -1519,6 +1574,7 @@
 15	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s56
+# parallel_id = zhgsd/test56
 # text = 《进化特区》（英文：Evolution）是2001年首映的一部美国科幻喜剧电影。
 # translit = «jìnhuàtèqū»(yīngwén:Evolution)shì2001niánshǒuyìngdeyībùměiguókēhuànxǐjùdiànyǐng.
 1	《	《	PUNCT	(	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -1545,6 +1601,7 @@
 22	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s57
+# parallel_id = zhgsd/test57
 # text = 游戏的任务重心就是“自由”。
 # translit = yóuxìderènwuzhòngxīnjiùshì“zìyóu”.
 1	游戏	游戏	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=yóuxì|LTranslit=yóuxì
@@ -1558,6 +1615,7 @@
 9	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s58
+# parallel_id = zhgsd/test58
 # text = NX-01最初的武器装备只有等离子炮与氚核鱼雷，并由电磁极化船甲保护。
 # translit = NX-01zuìchūdewǔqìzhuāngbèizhǐyǒuděnglízipàoyǔ氚héyúléi,bìngyóudiàncíjíhuàchuánjiǎbǎohù.
 1	NX-01	NX-01	X	FW	Foreign=Yes	5	nmod	_	SpaceAfter=No|Translit=NX-01|LTranslit=NX-01
@@ -1582,6 +1640,7 @@
 20	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s59
+# parallel_id = zhgsd/test59
 # text = 但在另一方面，少数变化使得分子的复制变得更快或更佳；这些“品系”的数量较多也较“成功”。
 # translit = dànzàilìngyīfāngmiàn,shǎoshùbiànhuàshǐdefēnzidefùzhìbiàndegèngkuàihuògèngjiā;zhèxiē“pǐnxì”deshùliàngjiàoduōyějiào“chénggōng”.
 1	但	但	SCONJ	RB	_	9	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -1617,6 +1676,7 @@
 31	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s60
+# parallel_id = zhgsd/test60
 # text = 1788年，他来到了所罗门圣克鲁斯群岛的，之后便杳无踪迹。
 # translit = 1788nián,tāláidàolesuǒluōménshèngkèlǔsīqúndǎode,zhīhòubiàn杳wúzōngjī.
 1	1788	1788	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1788|LTranslit=1788
@@ -1636,6 +1696,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s61
+# parallel_id = zhgsd/test61
 # text = 18世纪到19世纪是现代地质学和地理学的创立时期，两者的交叉领域则为地貌学提供了空间。
 # translit = 18shìjìdào19shìjìshìxiàndàidezhìxuéhédelǐxuédechuànglìshíqī,liǎngzhědejiāo叉lǐngyùzéwèidemàoxuétígōnglekōngjiān.
 1	18	18	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=18|LTranslit=18
@@ -1669,6 +1730,7 @@
 29	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s62
+# parallel_id = zhgsd/test62
 # text = 20世纪50年代也是地貌学出现分支学科的时期，形成了河流地貌学、冰川地貌学、海岸地貌学和构造地貌学。
 # translit = 20shìjì50niándàiyěshìdemàoxuéchūxiànfēnzhīxuékēdeshíqī,xíngchénglehéliúdemàoxué,bīngchuāndemàoxué,hǎi'àndemàoxuéhégòuzàodemàoxué.
 1	20	20	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=20|LTranslit=20
@@ -1704,6 +1766,7 @@
 31	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s63
+# parallel_id = zhgsd/test63
 # text = 化学中的场效应（Field effect，记作F）是指通过空间的分子内静电作用，即某取代基在空间产生一个电场，它对另一处的反应中心发生影响。
 # translit = huàxuézhōngdechǎngxiàoyīng(Field effect,jìzuòF)shìzhǐtōngguòkōngjiāndefēnzinèijìngdiànzuòyòng,jímǒuqǔdàijīzàikōngjiānchǎnshēngyīgèdiànchǎng,tāduìlìngyīchùdefǎnyīngzhōngxīnfāshēngyǐngxiǎng.
 1	化学	化学	NOUN	NN	_	5	nmod	_	SpaceAfter=No|Translit=huàxué|LTranslit=huàxué
@@ -1752,6 +1815,7 @@
 44	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s64
+# parallel_id = zhgsd/test64
 # text = 她并不十分擅长为唱片封面拍摄，每当摄影师把镜头对准她，说道：“好，开始拍”时，或者是在确定拍摄场景后，需要根据摄影师的想法去调整姿势时，她总是显得不自在。
 # translit = tābìngbùshífēn擅zhǎngwèichàngpiànfēngmiànpāishè,měidāngshèyǐngshībǎjìngtóuduìzhǔntā,shuōdào:“hǎo,kāishǐpāi”shí,huòzhěshìzàiquèdìngpāishèchǎngjǐnghòu,xūyàogēnjùshèyǐngshīdexiǎngfǎqùdiàozhěngzīshìshí,tāzǒngshìxiǎndebùzìzài.
 1	她	她	PRON	PRP	Person=3	5	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -1811,6 +1875,7 @@
 55	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s65
+# parallel_id = zhgsd/test65
 # text = 总之她对颜色的要求非常严格。
 # translit = zǒngzhītāduìyánsèdeyàoqiúfēichángyángé.
 1	总之	总之	ADV	RB	_	8	advmod	_	SpaceAfter=No|Translit=zǒngzhī|LTranslit=zǒngzhī
@@ -1824,6 +1889,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s66
+# parallel_id = zhgsd/test66
 # text = 此法既能解决运费高昂的问题，又可调节物价。
 # translit = cǐfǎjìnéngjiějuéyùnfèigāo'ángdewèntí,yòukědiàojiéwùjià.
 1	此法	此法	NOUN	NN	_	4	nsubj	_	SpaceAfter=No|Translit=cǐfǎ|LTranslit=cǐfǎ
@@ -1842,6 +1908,7 @@
 14	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s67
+# parallel_id = zhgsd/test67
 # text = 波利比奥斯记述道：“当其被不断切割，生还者被逼站在原地引颈就戮。”
 # translit = bōlìbǐ'àosījìshùdào:“dāngqíbèibùduànqiègē,shēngháizhěbèibīzhànzàiyuándeyǐnjǐngjiù戮.”
 1	波利比奥斯	波利比奥斯	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=bōlìbǐ'àosī|LTranslit=bōlìbǐ'àosī
@@ -1867,6 +1934,7 @@
 21	”	”	PUNCT	''	_	19	punct	_	SpaceAfter=No|Translit=”|LTranslit=”
 
 # sent_id = test-s68
+# parallel_id = zhgsd/test68
 # text = 总括而言，整场战役的总伤亡人数大约为八万人。
 # translit = zǒngkuò'éryán,zhěngchǎngzhànyìdezǒngshāngwángrénshùdàyuēwèibāwànrén.
 1	总括	总括	VERB	VV	_	3	advcl	_	SpaceAfter=No|Translit=zǒngkuò|LTranslit=zǒngkuò
@@ -1886,6 +1954,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s69
+# parallel_id = zhgsd/test69
 # text = 总面积11.37平方公里，总人口1579人，其中男性741人，女性838人（2011年12月31日），人口密度139人/平方公里。
 # translit = zǒngmiànjī11.37píngfānggōnglǐ,zǒngrénkǒu1579rén,qízhōngnánxìng741rén,nǚxìng838rén(2011nián12yuè31rì),rénkǒumìdù139rén/píngfānggōnglǐ.
 1	总	总	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=zǒng|LTranslit=zǒng
@@ -1924,6 +1993,7 @@
 34	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s70
+# parallel_id = zhgsd/test70
 # text = 有些现代神话学家认为，坎珀实际是厄客德娜的一个别名，两者之间有很多相似之处。
 # translit = yǒuxiēxiàndàishénhuàxuéjiārènwèi,kǎn珀shíjìshì厄kèdé娜deyīgèbiémíng,liǎngzhězhījiānyǒuhěnduōxiāngshìzhīchù.
 1	有些	有些	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=yǒuxiē|LTranslit=yǒuxiē
@@ -1953,6 +2023,7 @@
 25	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s71
+# parallel_id = zhgsd/test71
 # text = 他是一个典型的战士：高大，结实，强壮有力。
 # translit = tāshìyīgèdiǎnxíngdezhànshì:gāodà,jiéshí,qiángzhuàngyǒulì.
 1	他	他	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -1972,6 +2043,7 @@
 15	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s72
+# parallel_id = zhgsd/test72
 # text = 统治期内，梅葛处死了三位大学士；他还拥有为数众多的妻子，每个时期通常都不止一个，因此臭名远扬。
 # translit = tǒngzhìqīnèi,méi葛chùsǐlesānwèidàxuéshì;tāháiyōngyǒuwèishùzhòngduōdeqīzi,měigèshíqītōngchángdōubùzhǐyīgè,yīncǐchòumíngyuǎnyáng.
 1	统治	统治	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=tǒngzhì|LTranslit=tǒngzhì
@@ -2008,6 +2080,7 @@
 32	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s73
+# parallel_id = zhgsd/test73
 # text = 雷妮拉的母亲没有生下男性继承人就死了，所以韦赛里斯一世准备让雷妮拉继承王位，成为坦格利安家系中的第一位女王。
 # translit = léi妮lādemǔqīnméiyǒushēngxiànánxìngjìchéngrénjiùsǐle,suǒyǐ韦sàilǐsīyīshìzhǔnbèiràngléi妮lājìchéngwángwèi,chéngwèitǎngélì'ānjiāxìzhōngdedìyīwèinǚwáng.
 1	雷妮拉	雷妮拉	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=léi妮lā|LTranslit=léi妮lā
@@ -2043,6 +2116,7 @@
 31	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s74
+# parallel_id = zhgsd/test74
 # text = 由节目来宾各自抽签选定主持人当助手后分成两队比赛
 # translit = yóujiémùláibīngèzìchōuqiānxuǎndìngzhǔchíréndāngzhùshǒuhòufēnchéngliǎngduìbǐsài
 1	由	由	VERB	VV	_	15	advcl	_	SpaceAfter=No|Translit=yóu|LTranslit=yóu
@@ -2062,6 +2136,7 @@
 15	比赛	比赛	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=bǐsài|LTranslit=bǐsài
 
 # sent_id = test-s75
+# parallel_id = zhgsd/test75
 # text = 他亦曾代表过阿根廷国家队出赛，但并未参与任何世界杯赛事。
 # translit = tāyìcéngdàibiǎoguò'āgēntíngguójiāduìchūsài,dànbìngwèicānyǔrènhéshìjièbēisàishì.
 1	他	他	PRON	PRP	Person=3	14	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -2085,6 +2160,7 @@
 19	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s76
+# parallel_id = zhgsd/test76
 # text = 而埃姆登号的残骸在1950年被一家日本公司打捞上来作废铁处理，但仍有部分残骸未被打捞上来。
 # translit = 'ér'āimǔdēnghàodecán骸zài1950niánbèiyījiārìběngōngsīdǎlāoshàngláizuòfèitiěchùlǐ,dànréngyǒubùfēncán骸wèibèidǎlāoshànglái.
 1	而	而	SCONJ	RB	_	18	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -2118,6 +2194,7 @@
 29	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s77
+# parallel_id = zhgsd/test77
 # text = 根据美国舆论调查指出，当时隆美尔是美国仅次于希特勒的知名度最高的德国人。
 # translit = gēnjùměiguóyúlùndiàocházhǐchū,dāngshílóngměi'ěrshìměiguójǐncìyúxītèlēidezhīmíngdùzuìgāodedéguórén.
 1	根据	根据	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -2144,6 +2221,7 @@
 22	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s78
+# parallel_id = zhgsd/test78
 # text = 此处不需要保护补给线的安全而持续控制。
 # translit = cǐchùbùxūyàobǎohùbǔgěixiànde'ānquán'érchíxùkòngzhì.
 1	此处	此处	NOUN	NN	_	10	nsubj	_	SpaceAfter=No|Translit=cǐchù|LTranslit=cǐchù
@@ -2160,6 +2238,7 @@
 12	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s79
+# parallel_id = zhgsd/test79
 # text = 由于认为德义军队战力已就绪，隆美尔决定再发动攻势。
 # translit = yóuyúrènwèidéyìjūnduìzhànlìyǐjiùxù,lóngměi'ěrjuédìngzàifādònggōngshì.
 1	由于	由于	ADP	IN	_	11	mark	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -2179,6 +2258,7 @@
 15	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s80
+# parallel_id = zhgsd/test80
 # text = 起初隆美尔对此决定甚为恼怒，但回到司令部后重新考虑过后，隆美尔认为魏斯法尔的判断是正确的，中止了攻势。
 # translit = qǐchūlóngměi'ěrduìcǐjuédìngshénwèinǎonù,dànhuídàosīlìngbùhòuzhòngxīnkǎolǜguòhòu,lóngměi'ěrrènwèi魏sīfǎ'ěrdepànduànshìzhèngquède,zhōngzhǐlegōngshì.
 1	起初	起初	NOUN	NN	_	7	nmod:tmod	_	SpaceAfter=No|Translit=qǐchū|LTranslit=qǐchū
@@ -2214,6 +2294,7 @@
 31	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s81
+# parallel_id = zhgsd/test81
 # text = 该市镇总面积10.94平方公里，2009年时的人口为600人。
 # translit = gāishìzhènzǒngmiànjī10.94píngfānggōnglǐ,2009niánshíderénkǒuwèi600rén.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -2234,6 +2315,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s82
+# parallel_id = zhgsd/test82
 # text = 几个月后的一次采访，艾米说到：“如果我们没有变化的话，是没法做出第二张专辑的。”
 # translit = jǐgèyuèhòudeyīcìcǎifǎng,'àimǐshuōdào:“rúguǒwǒmenméiyǒubiànhuàdehuà,shìméifǎzuòchūdì'èrzhāngzhuānjide.”
 1	几	几	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=jǐ|LTranslit=jǐ
@@ -2266,6 +2348,7 @@
 28	”	”	PUNCT	''	_	20	punct	_	SpaceAfter=No|Translit=”|LTranslit=”
 
 # sent_id = test-s83
+# parallel_id = zhgsd/test83
 # text = 埃萨河是白俄罗斯的河流，由明斯克州和维捷布斯克州负责管辖，属于道加瓦河的一部分，该湖长84公里，面积1,040平方公里，最终注入列佩利湖。
 # translit = 'āisàhéshìbái'éluōsīdehéliú,yóumíngsīkèzhōuhéwéijiébùsīkèzhōufùzéguǎnxiá,shǔyúdàojiāwǎhédeyībùfēn,gāihúzhǎng84gōnglǐ,miànjī1,040píngfānggōnglǐ,zuìzhōngzhùrùlièpèilìhú.
 1	埃萨	埃萨	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit='āisà|LTranslit='āisà
@@ -2308,6 +2391,7 @@
 38	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s84
+# parallel_id = zhgsd/test84
 # text = 警方前往工作坊逮捕席勒的同时，也扣押了一百多张被认为是色情物品的画作。
 # translit = jǐngfāngqiánwǎnggōngzuòfangdǎibǔxílēidetóngshí,yěkòuyāleyībǎiduōzhāngbèirènwèishìsèqíngwùpǐndehuàzuò.
 1	警方	警方	NOUN	NN	_	11	nsubj	_	SpaceAfter=No|Translit=jǐngfāng|LTranslit=jǐngfāng
@@ -2334,6 +2418,7 @@
 22	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s85
+# parallel_id = zhgsd/test85
 # text = 卡斯特罗出现在了埃连与同学在一起的生日派对视频中。
 # translit = kǎsītèluōchūxiànzàile'āiliányǔtóngxuézàiyīqǐdeshēngrìpàiduìshìpínzhōng.
 1	卡斯特罗	卡斯特罗	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=kǎsītèluō|LTranslit=kǎsītèluō
@@ -2353,6 +2438,7 @@
 15	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s86
+# parallel_id = zhgsd/test86
 # text = 1916年至1917年，他在美国巡回演讲，之后的1920年，他被派任苏门答腊瑞典领事，1921年至1925年，他又来到美国学习。
 # translit = 1916niánzhì1917nián,tāzàiměiguóxúnhuíyǎnjiǎng,zhīhòude1920nián,tābèipàirènsūméndá腊ruìdiǎnlǐngshì,1921niánzhì1925nián,tāyòuláidàoměiguóxuéxí.
 1	1916	1916	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1916|LTranslit=1916
@@ -2393,6 +2479,7 @@
 36	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s87
+# parallel_id = zhgsd/test87
 # text = 曼施坦因战后继续留在军队，在1920年代，他参与了创建德国国防军的进程，1919年5月的《凡尔赛条约》限定魏玛共和国只能拥有最多10万人的军队。
 # translit = mànshītǎnyīnzhànhòujìxùliúzàijūnduì,zài1920niándài,tācānyǔlechuàngjiàndéguóguófángjūndejìnchéng,1919nián5yuède«fán'ěrsàitiáoyuē»xiàndìng魏mǎgònghéguózhǐnéngyōngyǒuzuìduō10wànréndejūnduì.
 1	曼施坦因	曼施坦因	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit=mànshītǎnyīn|LTranslit=mànshītǎnyīn
@@ -2440,6 +2527,7 @@
 43	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s88
+# parallel_id = zhgsd/test88
 # text = 1918年，他被派去指挥占领白俄罗斯的第十军，在那里他一直待到战争结束。
 # translit = 1918nián,tābèipàiqùzhǐhuīzhànlǐngbái'éluōsīdedìshíjūn,zàinàlǐtāyīzhídàidàozhànzhēngjiéshù.
 1	1918	1918	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1918|LTranslit=1918
@@ -2465,6 +2553,7 @@
 21	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s89
+# parallel_id = zhgsd/test89
 # text = 虽然她从来没有再婚，她又找了几任情人，并于1882年去世。
 # translit = suīrántācóngláiméiyǒuzàihūn,tāyòuzhǎolejǐrènqíngrén,bìngyú1882niánqùshì.
 1	虽然	虽然	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -2489,6 +2578,7 @@
 20	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s90
+# parallel_id = zhgsd/test90
 # text = 这个长廊顶部覆盖着拱形的玻璃和铸铁屋顶，这是19世纪流行的商场设计。
 # translit = zhègèzhǎng廊dǐngbùfùgàizhegǒngxíngdebōlíhézhùtiěwūdǐng,zhèshì19shìjìliúxíngdeshāngchǎngshèjì.
 1	这	这	DET	DT	_	4	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -2515,6 +2605,7 @@
 22	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s91
+# parallel_id = zhgsd/test91
 # text = 城东湖是一个位于中国安徽省霍丘县的湖泊，面积约为115平方千米。
 # translit = chéngdōnghúshìyīgèwèiyúzhōngguó'ān徽shěng霍qiūxiàndehúpō,miànjīyuēwèi115píngfāngqiānmǐ.
 1	城东	城东	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=chéngdōng|LTranslit=chéngdōng
@@ -2540,6 +2631,7 @@
 21	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s92
+# parallel_id = zhgsd/test92
 # text = 评论家们特别赞赏了阿弗莱克对于抢劫场景的导演手法。
 # translit = pínglùnjiāmentèbiézànshǎngle'āfú莱kèduìyúqiǎng劫chǎngjǐngdedǎoyǎnshǒufǎ.
 1	评论	评论	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=pínglùn|LTranslit=pínglùn
@@ -2558,6 +2650,7 @@
 14	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s93
+# parallel_id = zhgsd/test93
 # text = 随着年代的变迁，城堡设计的美学因素越来越重要，城堡的外观和规模开始体现它的居住者的威望和权力。
 # translit = suízheniándàidebiànqiān,chéngbǎoshèjìdeměixuéyīnsùyuèláiyuèzhòngyào,chéngbǎodewàiguānhéguīmókāishǐtǐxiàntādejūzhùzhědewēiwànghéquánlì.
 1	随	随	VERB	VV	_	13	advcl	_	SpaceAfter=No|Translit=suí|LTranslit=suí
@@ -2592,6 +2685,7 @@
 30	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s94
+# parallel_id = zhgsd/test94
 # text = 以下资料以2008年清明节为准。
 # translit = yǐxiàzīliàoyǐ2008niánqīngmíngjiéwèizhǔn.
 1	以下	以下	DET	DT	_	2	det	_	SpaceAfter=No|Translit=yǐxià|LTranslit=yǐxià
@@ -2606,6 +2700,7 @@
 10	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s95
+# parallel_id = zhgsd/test95
 # text = 每日0515-0545班次到达石排湾道后，绕经华富道及华富（南）巴士总站，再返回石排湾道原有路线。
 # translit = měirì0515-0545bāncìdàodáshípáiwāndàohòu,ràojīnghuáfùdàojíhuáfù(nán)bashìzǒngzhàn,zàifǎnhuíshípáiwāndàoyuányǒulùxiàn.
 1	每日	每日	DET	DT	_	5	det	_	SpaceAfter=No|Translit=měirì|LTranslit=měirì
@@ -2640,6 +2735,7 @@
 30	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s96
+# parallel_id = zhgsd/test96
 # text = 教会每周有许多不同的聚会，分别有英文、中文、福建话、广东话、与印尼文聚会。
 # translit = jiàohuìměizhōuyǒuxǔduōbùtóngdejùhuì,fēnbiéyǒuyīngwén,zhōngwén,fújiànhuà,guǎngdōnghuà,yǔyìnníwénjùhuì.
 1	教会	教会	NOUN	NN	_	10	nsubj	_	SpaceAfter=No|Translit=jiàohuì|LTranslit=jiàohuì
@@ -2671,6 +2767,7 @@
 27	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s97
+# parallel_id = zhgsd/test97
 # text = 河姆渡遗址和仰韶遗址出土被认为最原始的陶埙均只有吹孔，而无音孔。
 # translit = hémǔdùyízhǐhéyǎng韶yízhǐchūtǔbèirènwèizuìyuánshǐdetáo埙jūnzhǐyǒuchuīkǒng,'érwúyīnkǒng.
 1	河姆渡	河姆渡	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=dù|LTranslit=dù
@@ -2695,6 +2792,7 @@
 20	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s98
+# parallel_id = zhgsd/test98
 # text = 我们已经提及了连续偏序集合和代数偏序集合。
 # translit = wǒmenyǐjīngtíjíleliánxùpiānxùjíhéhédàishùpiānxùjíhé.
 1	我们	我	PRON	PRP	Number=Plur|Person=1	3	nsubj	_	SpaceAfter=No|Translit=wǒmen|LTranslit=wǒ
@@ -2711,6 +2809,7 @@
 12	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s99
+# parallel_id = zhgsd/test99
 # text = 另一种观点认为，两种复制的基因同样都会累积退化的突变，基因重复的缺陷也能相辅相成。
 # translit = lìngyīzhǒngguāndiǎnrènwèi,liǎngzhǒngfùzhìdejīyīntóngyàngdōuhuìlèijītuìhuàdetūbiàn,jīyīnzhòngfùdequēxiànyěnéngxiāngfǔxiāngchéng.
 1	另	另	DET	DT	_	3	det	_	SpaceAfter=No|Translit=lìng|LTranslit=lìng
@@ -2742,6 +2841,7 @@
 27	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s100
+# parallel_id = zhgsd/test100
 # text = 他感到自责，认为这样的复仇超过了应有的界限。
 # translit = tāgǎndàozìzé,rènwèizhèyàngdefùchóuchāoguòleyīngyǒudejièxiàn.
 1	他	他	PRON	PRP	Person=3	5	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -2761,6 +2861,7 @@
 15	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s101
+# parallel_id = zhgsd/test101
 # text = 在格连推动之下，大陆军在12日决议即时撤出纽约，优先把伤兵及补给送到哈林高地，并由以色列·普特南的4,000人殿后。
 # translit = zàigéliántuīdòngzhīxià,dàlùjūnzài12rìjuéyìjíshíchèchūniǔyuē,yōuxiānbǎshāngbīngjíbǔgěisòngdàohālíngāode,bìngyóuyǐsèliè·pǔtènánde4,000réndiànhòu.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -2799,6 +2900,7 @@
 34	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s102
+# parallel_id = zhgsd/test102
 # text = 翌日（9月16日）一支英军向北侦察时与美军交火，引发哈林高地战役。
 # translit = 翌rì(9yuè16rì)yīzhīyīngjūnxiàngběizhēncháshíyǔměijūnjiāohuǒ,yǐnfāhālíngāodezhànyì.
 1	翌日	翌日	NOUN	NN	_	19	nmod:tmod	_	SpaceAfter=No|Translit=翌rì|LTranslit=翌rì
@@ -2828,6 +2930,7 @@
 25	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s103
+# parallel_id = zhgsd/test103
 # text = 英军军舰向基普湾狂轰滥炸近一小时，使滩头浓烟密布。
 # translit = yīngjūnjūnjiànxiàngjīpǔwānkuánghōnglànzhàjìnyīxiǎoshí,shǐtāntóunóngyānmìbù.
 1	英	英	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=yīng|LTranslit=yīng
@@ -2848,6 +2951,7 @@
 16	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s104
+# parallel_id = zhgsd/test104
 # text = 华盛顿希望先获得大陆议会准许撤退，然后把纽约市彻底焚毁；部分将军则主张死守纽约，等待英军正面进攻，以重演邦克山战役的战果。
 # translit = huáshèngdùnxīwàngxiānhuòdedàlùyìhuìzhǔnxǔchètuì,ránhòubǎniǔyuēshìchèdǐ焚huǐ;bùfēnjiāngjūnzézhǔzhāngsǐshǒuniǔyuē,děngdàiyīngjūnzhèngmiànjìngōng,yǐzhòngyǎnbāngkèshānzhànyìdezhànguǒ.
 1	华盛顿	华盛顿	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=huáshèngdùn|LTranslit=huáshèngdùn
@@ -2889,6 +2993,7 @@
 37	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s105
+# parallel_id = zhgsd/test105
 # text = 长岛会战后，大陆军撤回曼哈顿岛，但在撤离纽约市一事上仍然犹豫不决。
 # translit = zhǎngdǎohuìzhànhòu,dàlùjūnchèhuímànhādùndǎo,dànzàichèlíniǔyuēshìyīshìshàngréngrányóuyùbùjué.
 1	长岛	长岛	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=zhǎngdǎo|LTranslit=zhǎngdǎo
@@ -2914,6 +3019,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s106
+# parallel_id = zhgsd/test106
 # text = 程序性给付是在要求国家必须提供一套制度，例如考试制度和选举制度等，其也与正当法律程序条款的要求有关。
 # translit = chéngxùxìnggěifùshìzàiyàoqiúguójiābìxūtígōngyītàozhìdù,lìrúkǎoshìzhìdùhéxuǎnjǔzhìdùděng,qíyěyǔzhèngdāngfǎlǜchéngxùtiáokuǎndeyàoqiúyǒuguān.
 1	程序	程序	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=chéngxù|LTranslit=chéngxù
@@ -2950,6 +3056,7 @@
 32	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s107
+# parallel_id = zhgsd/test107
 # text = 主武器是20枚P-700花岗岩（厂号3M45）反舰飞弹（分装在20座垂直发射器里），可以击沉大型水面舰。
 # translit = zhǔwǔqìshì20méiP-700huāgǎngyán(chǎnghào3M45)fǎnjiànfēidàn(fēnzhuāngzài20zuòchuízhífāshèqìlǐ),kěyǐjīchéndàxíngshuǐmiànjiàn.
 1	主	主	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=zhǔ|LTranslit=zhǔ
@@ -2985,6 +3092,7 @@
 31	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s108
+# parallel_id = zhgsd/test108
 # text = 根据分析它和德国209型艇的静音性能在伯仲之间。
 # translit = gēnjùfēnxītāhédéguó209xíngtǐngdejìngyīnxìngnéngzàibó仲zhījiān.
 1	根据	根据	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -3003,6 +3111,7 @@
 14	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s109
+# parallel_id = zhgsd/test109
 # text = 基督堂草坪（Christ Church Meadow）是英国牛津一个著名的洪水草甸，和著名的步行和野餐地点。
 # translit = jīdūtángcǎo坪(Christ Church Meadow)shìyīngguóniújīnyīgèzhemíngdehóngshuǐcǎodiān,hézhemíngdebùxínghéyěcāndediǎn.
 1	基督	基督	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=jīdū|LTranslit=jīdū
@@ -3033,6 +3142,7 @@
 26	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s110
+# parallel_id = zhgsd/test110
 # text = 在报复的过程中，报复者会产生一种罪恶的快感。
 # translit = zàibàofùdeguòchéngzhōng,bàofùzhěhuìchǎnshēngyīzhǒngzuì'èdekuàigǎn.
 1	在	在	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -3053,6 +3163,7 @@
 16	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s111
+# parallel_id = zhgsd/test111
 # text = 该事件被称为睿问魔谋杀案。
 # translit = gāishìjiànbèichēngwèi睿wènmómóushā'àn.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -3066,6 +3177,7 @@
 9	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s112
+# parallel_id = zhgsd/test112
 # text = 塔尔卡受地中海气候影响，有干燥的夏天和潮湿的冬天，每年平均降雨量749毫米，平均温度摄氏13度。
 # translit = tǎ'ěrkǎshòudezhōnghǎiqìhouyǐngxiǎng,yǒugànzàodexiàtiānhécháoshīdedōngtiān,měiniánpíngjūnjiàngyǔliàng749háomǐ,píngjūnwēndùshèshì13dù.
 1	塔尔卡	塔尔卡	PROPN	NNP	_	8	nsubj	_	SpaceAfter=No|Translit=tǎ'ěrkǎ|LTranslit=tǎ'ěrkǎ
@@ -3099,6 +3211,7 @@
 29	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s113
+# parallel_id = zhgsd/test113
 # text = 她出生的日期已无法确定，因为她的出生记录已在处决时被销毁。
 # translit = tāchūshēngderìqīyǐwúfǎquèdìng,yīnwèitādechūshēngjìlùyǐzàichùjuéshíbèixiāohuǐ.
 1	她	她	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -3123,6 +3236,7 @@
 20	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s114
+# parallel_id = zhgsd/test114
 # text = 她是伊朗的巴比教有影响力的诗人和神学家。
 # translit = tāshìyīlǎngdebabǐjiàoyǒuyǐngxiǎnglìdeshīrénhéshénxuéjiā.
 1	她	她	PRON	PRP	Person=3	11	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -3142,6 +3256,7 @@
 15	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s115
+# parallel_id = zhgsd/test115
 # text = 很快，她就因为热情地传播信仰和“无畏的忠信”同时赢得了声望和恶名。
 # translit = hěnkuài,tājiùyīnwèirèqíngdechuánbōxìnyǎnghé“wúwèidezhōngxìn”tóngshí赢deleshēngwànghé'èmíng.
 1	很快	很快	ADV	RB	_	17	advmod	_	SpaceAfter=No|Translit=hěnkuài|LTranslit=hěnkuài
@@ -3168,6 +3283,7 @@
 22	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s116
+# parallel_id = zhgsd/test116
 # text = 查尔斯·克拉克在其同年出版的专著《苏门答腊岛与西马来西亚的猪笼草》中拒绝这一观点。
 # translit = chá'ěrsī·kèlākèzàiqítóngniánchūbǎndezhuānzhe«sūméndá腊dǎoyǔximǎláixiyàdezhūlóngcǎo»zhōngjùjuézhèyīguāndiǎn.
 1	查尔斯	查尔斯	PROPN	NNP	_	20	nsubj	_	SpaceAfter=No|Translit=chá'ěrsī|LTranslit=chá'ěrsī
@@ -3196,6 +3312,7 @@
 24	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s117
+# parallel_id = zhgsd/test117
 # text = 他先在印度西姆拉上学，后来毕业于加州帕萨迪纳的艺术设计中心学院。
 # translit = tāxiānzàiyìndùximǔlāshàngxué,hòuláibìyèyújiāzhōupàsàdínàdeyìshùshèjìzhōngxīnxuéyuàn.
 1	他	他	PRON	PRP	Person=3	9	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -3218,6 +3335,7 @@
 18	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s118
+# parallel_id = zhgsd/test118
 # text = 1553年，太美斯普一世抵御了奥斯曼帝国苏丹苏里曼一世的进攻。
 # translit = 1553nián,tàiměisīpǔyīshìdǐyùle'àosīmàndìguósūdānsūlǐmànyīshìdejìngōng.
 1	1553	1553	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1553|LTranslit=1553
@@ -3237,6 +3355,7 @@
 15	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s119
+# parallel_id = zhgsd/test119
 # text = 2003年，阿齐兹向美军投降。
 # translit = 2003nián,'āqí兹xiàngměijūntóujiàng.
 1	2003	2003	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2003|LTranslit=2003
@@ -3250,6 +3369,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s120
+# parallel_id = zhgsd/test120
 # text = 这是阿齐兹的第一项死刑，他因1992年处死42名商人而被判15年有期徒刑。
 # translit = zhèshì'āqí兹dedìyīxiàngsǐxíng,tāyīn1992niánchùsǐ42míngshāngrén'érbèipàn15niányǒuqītúxíng.
 1	这	这	PRON	PRD	_	7	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -3278,6 +3398,7 @@
 24	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s121
+# parallel_id = zhgsd/test121
 # text = 塔里木盆地的塔克拉玛干沙漠流沙严重，从谷歌卫星图片可以清晰看到，沙漠腹地有些已建成的公路由于固沙措施不力，导致公路抵御流沙的力度不够，许多连接油田基地的沥青路面被强大的流动沙丘所淹没，阻断交通。
 # translit = tǎlǐmùpéndedetǎkèlāmǎgànshāmòliúshāyánzhòng,cónggǔgēwèixīngtúpiànkěyǐqīngxīkàndào,shāmòfùdeyǒuxiēyǐjiànchéngdegōnglùyóuyúgùshācuòshībùlì,dǎozhìgōnglùdǐyùliúshādelìdùbùgòu,xǔduōliánjiēyóutiánjīdedelìqīnglùmiànbèiqiángdàdeliúdòngshāqiūsuǒyānméi,zǔduànjiāotōng.
 1	塔里木	塔里木	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=tǎlǐmù|LTranslit=tǎlǐmù
@@ -3336,6 +3457,7 @@
 54	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s122
+# parallel_id = zhgsd/test122
 # text = 其中一处甚至涂有“小心恶犬”的标语。
 # translit = qízhōngyīchùshénzhìtuyǒu“xiǎoxīn'èquǎn”debiāoyǔ.
 1	其中	其中	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=qízhōng|LTranslit=qízhōng
@@ -3352,6 +3474,7 @@
 12	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s123
+# parallel_id = zhgsd/test123
 # text = 任何人类的法则倘若与此法则相矛盾，便丧失其效力；而具有效力的法律，其全部法力、效力和权威则都是间接地或直接地从这一根源产生的。
 # translit = rènhérénlèidefǎzétǎngruòyǔcǐfǎzéxiāngmáodùn,biànsàngshīqíxiàolì;'érjùyǒuxiàolìdefǎlǜ,qíquánbùfǎlì,xiàolìhéquánwēizédōushìjiānjiēdehuòzhíjiēdecóngzhèyīgēnyuánchǎnshēngde.
 1	任何	任何	DET	DT	_	4	det	_	SpaceAfter=No|Translit=rènhé|LTranslit=rènhé
@@ -3399,6 +3522,7 @@
 43	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s124
+# parallel_id = zhgsd/test124
 # text = 男人宣称，根据使徒教义，妇女不得任牧师，除了个别例外的，妇女还不得在公共场合参与宗教事务。
 # translit = nánrénxuānchēng,gēnjùshǐtújiàoyì,fùnǚbùderènmùshī,chúlegèbiélìwàide,fùnǚháibùdezàigōnggòngchǎnghécānyǔzōngjiàoshìwu.
 1	男人	男人	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=nánrén|LTranslit=nánrén
@@ -3431,6 +3555,7 @@
 28	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s125
+# parallel_id = zhgsd/test125
 # text = 男人强迫妇女服从那些她无权参与制定的法律。
 # translit = nánrénqiángpòfùnǚfúcóngnàxiētāwúquáncānyǔzhìdìngdefǎlǜ.
 1	男人	男人	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=nánrén|LTranslit=nánrén
@@ -3447,6 +3572,7 @@
 12	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s126
+# parallel_id = zhgsd/test126
 # text = 詹姆斯和莫特对这项权益持相反的态度。
 # translit = 詹mǔsīhémòtèduìzhèxiàngquányìchíxiāngfǎndetàidù.
 1	詹姆斯	詹姆斯	PROPN	NNP	_	8	nsubj	_	SpaceAfter=No|Translit=詹mǔsī|LTranslit=詹mǔsī
@@ -3463,6 +3589,7 @@
 12	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s127
+# parallel_id = zhgsd/test127
 # text = 1896年至1973年间，该站为地上车站。
 # translit = 1896niánzhì1973niánjiān,gāizhànwèideshàngchēzhàn.
 1	1896	1896	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1896|LTranslit=1896
@@ -3479,6 +3606,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s128
+# parallel_id = zhgsd/test128
 # text = 人们建造了一个纪念公园，并且为受害者放置了纪念石凳。
 # translit = rénmenjiànzàoleyīgèjìniàngōngyuán,bìngqiěwèishòuhàizhěfàngzhìlejìniànshídèng.
 1	人们	人	NOUN	NN	Number=Plur	13	nsubj	_	SpaceAfter=No|Translit=rénmen|LTranslit=rén
@@ -3500,6 +3628,7 @@
 17	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s129
+# parallel_id = zhgsd/test129
 # text = 古罗马人利用拱结构来支撑桥身石材与水流的重量。
 # translit = gǔluōmǎrénlìyònggǒngjiégòuláizhīchēngqiáoshēnshícáiyǔshuǐliúdezhòngliàng.
 1	古	古	PART	PFA	_	2	case	_	SpaceAfter=No|Translit=gǔ|LTranslit=gǔ
@@ -3519,6 +3648,7 @@
 15	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s130
+# parallel_id = zhgsd/test130
 # text = 不过有些会影响到玩家的游戏体验的老版程序错误，我们不得不修复了它们，所以有些原版《时之笛》存在的bug将不复存在。
 # translit = bùguòyǒuxiēhuìyǐngxiǎngdàowánjiādeyóuxìtǐyàndelǎobǎnchéngxùcuòwù,wǒmenbùdebùxiūfùletāmen,suǒyǐyǒuxiēyuánbǎn«shízhīdí»cúnzàidebugjiāngbùfùcúnzài.
 1	不过	不过	SCONJ	RB	_	2	mark	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -3559,6 +3689,7 @@
 36	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s131
+# parallel_id = zhgsd/test131
 # text = 该市镇总面积9.58平方公里，2009年时的人口为81人。
 # translit = gāishìzhènzǒngmiànjī9.58píngfānggōnglǐ,2009niánshíderénkǒuwèi81rén.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -3579,6 +3710,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s132
+# parallel_id = zhgsd/test132
 # text = 塞普勒斯众议院共有59个议席，每5年改选一届。
 # translit = sāipǔlēisīzhòngyìyuàngòngyǒu59gèyìxí,měi5niángǎixuǎnyījiè.
 1	塞普勒斯	塞普勒斯	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=sāipǔlēisī|LTranslit=sāipǔlēisī
@@ -3599,6 +3731,7 @@
 16	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s133
+# parallel_id = zhgsd/test133
 # text = 自1960年代以后塞维亚实力每况愈下，只能在低组别联赛打滚，至1990年代末才升上甲组。
 # translit = zì1960niándàiyǐhòusāiwéiyàshílìměikuàngyùxià,zhǐnéngzàidīzǔbiéliánsàidǎgǔn,zhì1990niándàimòcáishēngshàngjiǎzǔ.
 1	自	自	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zì|LTranslit=zì
@@ -3627,6 +3760,7 @@
 24	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s134
+# parallel_id = zhgsd/test134
 # text = 2000年代九广铁路计划兴建落马洲支线经过该地，引起了对该处生态影响的关注。
 # translit = 2000niándàijiǔguǎngtiělùjìhuàxìngjiànluòmǎzhōuzhīxiànjīngguògāide,yǐnqǐleduìgāichùshēngtàiyǐngxiǎngdeguānzhù.
 1	2000	2000	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2000|LTranslit=2000
@@ -3653,6 +3787,7 @@
 22	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s135
+# parallel_id = zhgsd/test135
 # text = 墨尔本在服饰、艺术、音乐、电视制作、电影及舞蹈等潮流文化领域引领澳洲，甚至于全球该领域范围都具备一定的影响力。
 # translit = mò'ěrběnzàifúshì,yìshù,yīnlè,diànshìzhìzuò,diànyǐngjíwǔdǎoděngcháoliúwénhuàlǐngyùyǐnlǐng'àozhōu,shénzhìyúquánqiúgāilǐngyùfànwéidōujùbèiyīdìngdeyǐngxiǎnglì.
 1	墨尔本	墨尔本	PROPN	NNP	_	29	nsubj	_	SpaceAfter=No|Translit=mò'ěrběn|LTranslit=mò'ěrběn
@@ -3691,6 +3826,7 @@
 34	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s136
+# parallel_id = zhgsd/test136
 # text = 2013年，历史悠久的墨尔本大学即将迎来自己的160周年校庆。
 # translit = 2013nián,lìshǐyōujiǔdemò'ěrběndàxuéjíjiāngyíngláizìjǐde160zhōuniánxiàoqìng.
 1	2013	2013	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2013|LTranslit=2013
@@ -3711,6 +3847,7 @@
 16	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s137
+# parallel_id = zhgsd/test137
 # text = 1932年（昭和7年）北部成立向岛区。
 # translit = 1932nián(昭hé7nián)běibùchénglìxiàngdǎoqū.
 1	1932	1932	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1932|LTranslit=1932
@@ -3727,6 +3864,7 @@
 12	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s138
+# parallel_id = zhgsd/test138
 # text = 虽然这些小吃一般不被视作正餐，但即使作为前菜，有时它的丰腻也令人吃得很饱肚。
 # translit = suīránzhèxiēxiǎochīyībānbùbèishìzuòzhèngcān,dànjíshǐzuòwèiqiáncài,yǒushítādefēng腻yělìngrénchīdehěnbǎodù.
 1	虽然	虽然	ADP	IN	_	7	case	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -3758,6 +3896,7 @@
 27	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s139
+# parallel_id = zhgsd/test139
 # text = 国际壁球联盟（IRF）于1979年由十三个国家共同成立，在努力推广发展下，80年代早期在五大洲就超过80个国家参与壁球的活动。
 # translit = guójìbìqiúliánméng(IRF)yú1979niányóushísāngèguójiāgòngtóngchénglì,zàinǔlìtuīguǎngfāzhǎnxià,80niándàizǎoqīzàiwǔdàzhōujiùchāoguò80gèguójiācānyǔbìqiúdehuódòng.
 1	国际	国际	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=guójì|LTranslit=guójì
@@ -3800,6 +3939,7 @@
 38	。	。	PUNCT	.	_	30	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s140
+# parallel_id = zhgsd/test140
 # text = 润滑剂中加入其它物质可以控制乳液粘度以及热学性能。
 # translit = rùnhuájìzhōngjiārùqítāwùzhìkěyǐkòngzhìrǔyèzhāndùyǐjírèxuéxìngnéng.
 1	润滑	润滑	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=rùnhuá|LTranslit=rùnhuá
@@ -3818,6 +3958,7 @@
 14	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s141
+# parallel_id = zhgsd/test141
 # text = 然后推杆就会推出所有的铸件，由于一个模具内可能会有多个模腔，所以每次铸造过程中可能会产生多个铸件。
 # translit = ránhòutuīgānjiùhuìtuīchūsuǒyǒudezhùjiàn,yóuyúyīgèmójùnèikěnénghuìyǒuduōgèmóqiāng,suǒyǐměicìzhùzàoguòchéngzhōngkěnénghuìchǎnshēngduōgèzhùjiàn.
 1	然后	然后	ADV	RB	_	5	advmod	_	SpaceAfter=No|Translit=ránhòu|LTranslit=ránhòu
@@ -3855,6 +3996,7 @@
 33	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s142
+# parallel_id = zhgsd/test142
 # text = 熔融金属可以从这里进入模具，这个部位的形状同热室压铸中的注射嘴或是冷室压铸中的注射室相匹配。
 # translit = róngróngjīnshǔkěyǐcóngzhèlǐjìnrùmójù,zhègèbùwèidexíngzhuàngtóngrèshìyāzhùzhōngdezhùshèzuǐhuòshìlěngshìyāzhùzhōngdezhùshèshìxiāngpǐpèi.
 1	熔融	熔融	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=róngróng|LTranslit=róngróng
@@ -3889,6 +4031,7 @@
 30	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s143
+# parallel_id = zhgsd/test143
 # text = 因为这里是两条河川（士别川、剑渊川）汇合至天盐川的地方。
 # translit = yīnwèizhèlǐshìliǎngtiáohéchuān(shìbiéchuān,jiàn渊chuān)huìhézhìtiānyánchuāndedefāng.
 1	因为	因为	ADP	IN	_	0	root	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -3913,6 +4056,7 @@
 20	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s144
+# parallel_id = zhgsd/test144
 # text = 在雇用一位法语向导后，旅行者及其随从就前往巴黎。
 # translit = zàigùyòngyīwèifǎyǔxiàngdǎohòu,lǚxíngzhějíqísuícóngjiùqiánwǎngbalí.
 1	在	在	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -3935,6 +4079,7 @@
 18	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s145
+# parallel_id = zhgsd/test145
 # text = 欧洲旅行是一件微不足道的事，景色乏味、清一色、缺少变化”。
 # translit = 'ōuzhōulǚxíngshìyījiànwēibùzúdàodeshì,jǐngsèfáwèi,qīngyīsè,quēshǎobiànhuà”.
 1	欧洲	欧洲	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit='ōuzhōu|LTranslit='ōuzhōu
@@ -3959,6 +4104,7 @@
 20	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s146
+# parallel_id = zhgsd/test146
 # text = 此理论既避免了浊送气音的不对称，也可以在一定程度上解释同源词在各派生语中的词形差异。
 # translit = cǐlǐlùnjìbìmiǎnlezhuósòngqìyīndebùduìchēng,yěkěyǐzàiyīdìngchéngdùshàngjiěshìtóngyuáncízàigèpàishēngyǔzhōngdecíxíngchàyì.
 1	此	此	DET	DT	_	2	det	_	SpaceAfter=No|Translit=cǐ|LTranslit=cǐ
@@ -3993,6 +4139,7 @@
 30	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s147
+# parallel_id = zhgsd/test147
 # text = 这个原理有时叫做弗雷格原理，因为普遍认为弗雷格首先公式化了它。
 # translit = zhègèyuánlǐyǒushíjiàozuòfúléigéyuánlǐ,yīnwèipǔbiànrènwèifúléigéshǒuxiāngōngshìhuàletā.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -4015,6 +4162,7 @@
 18	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s148
+# parallel_id = zhgsd/test148
 # text = 1915年，时任校长李登辉改革课程体系，课程分成八大部类，其中哲学部为首，并亲自讲授哲学类课程；复旦大学逐渐建立起由逻辑、伦理、性理（包括心理学与形而上学）组成的哲学教学体系。
 # translit = 1915nián,shírènxiàozhǎnglidēnghuīgǎigékèchéngtǐxì,kèchéngfēnchéngbādàbùlèi,qízhōngzhéxuébùwèishǒu,bìngqīnzìjiǎngshòuzhéxuélèikèchéng;fùdàndàxuézhújiànjiànlìqǐyóuluóji,lúnlǐ,xìnglǐ(bāokuòxīnlǐxuéyǔxíng'érshàngxué)zǔchéngdezhéxuéjiàoxuétǐxì.
 1	1915	1915	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1915|LTranslit=1915
@@ -4074,6 +4222,7 @@
 55	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s149
+# parallel_id = zhgsd/test149
 # text = 2000年，成立复旦大学科学技术与社会发展研究中心。
 # translit = 2000nián,chénglìfùdàndàxuékēxuéjìshùyǔshèhuìfāzhǎnyánjiūzhōngxīn.
 1	2000	2000	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2000|LTranslit=2000
@@ -4092,6 +4241,7 @@
 14	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s150
+# parallel_id = zhgsd/test150
 # text = 2009年，贝拉克·奥巴马正式地邀请同性配偶及其子女出席复活节滚彩蛋活动。
 # translit = 2009nián,bèilākè·'àobamǎzhèngshìdeyāoqǐngtóngxìngpèi'ǒujíqízinǚchūxífùhuójiégǔncǎidànhuódòng.
 1	2009	2009	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2009|LTranslit=2009
@@ -4117,6 +4267,7 @@
 21	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s151
+# parallel_id = zhgsd/test151
 # text = 后来，夏志明被伯明翰邀请接受测试，他参与了一场预备组赛事后，得知不会获得合约后决定于英国停学，于同年12月返回香港跟随杰志参与操练。
 # translit = hòulái,xiàzhìmíngbèibómíng翰yāoqǐngjiēshòucèshì,tācānyǔleyīchǎngyùbèizǔsàishìhòu,dezhībùhuìhuòdehéyuēhòujuédìngyúyīngguótíngxué,yútóngnián12yuèfǎnhuíxiānggǎnggēnsuíjiézhìcānyǔcāoliàn.
 1	后来	后来	NOUN	NN	_	8	nmod:tmod	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -4162,6 +4313,7 @@
 41	。	。	PUNCT	.	_	39	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s152
+# parallel_id = zhgsd/test152
 # text = 影片也从田纳西·威廉斯的《热铁皮屋顶上的猫》中汲取了灵感。
 # translit = yǐngpiànyěcóngtiánnàxi·wēiliánsīde«rètiěpíwūdǐngshàngdemāo»zhōng汲qǔlelínggǎn.
 1	影片	影片	NOUN	NN	_	17	nsubj	_	SpaceAfter=No|Translit=yǐngpiàn|LTranslit=yǐngpiàn
@@ -4186,6 +4338,7 @@
 20	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s153
+# parallel_id = zhgsd/test153
 # text = 太康只顾游玩，不理政事，在位期间，夏部族权威削弱，东夷族太昊与少昊部落趁机西进。
 # translit = tàikāngzhǐgùyóuwán,bùlǐzhèngshì,zàiwèiqījiān,xiàbùzúquánwēixuēruò,dōng夷zútài昊yǔshǎo昊bùluòchènjīxijìn.
 1	太康	太康	PROPN	NNP	_	6	nsubj	_	SpaceAfter=No|Translit=tàikāng|LTranslit=tàikāng
@@ -4215,6 +4368,7 @@
 25	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s154
+# parallel_id = zhgsd/test154
 # text = 夏绿蒂从1839年开始在约克郡担任许多家庭的女教师，直到1841年为止。
 # translit = xiàlǜdìcóng1839niánkāishǐzàiyuēkè郡dānrènxǔduōjiātíngdenǚjiàoshī,zhídào1841niánwèizhǐ.
 1	夏绿蒂	夏绿蒂	PROPN	NNP	_	9	nsubj	_	SpaceAfter=No|Translit=xiàlǜdì|LTranslit=xiàlǜdì
@@ -4240,6 +4394,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s155
+# parallel_id = zhgsd/test155
 # text = 1965年12月14日，夏继泉在北京病逝。
 # translit = 1965nián12yuè14rì,xiàjìquánzàiběijīngbìngshì.
 1	1965	1965	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1965|LTranslit=1965
@@ -4257,6 +4412,7 @@
 13	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s156
+# parallel_id = zhgsd/test156
 # text = 日本人提出请夏继泉出任山东省省长，后来又提出请他任教育督办等职务，均被夏继泉拒绝。
 # translit = rìběnréntíchūqǐngxiàjìquánchūrènshāndōngshěngshěngzhǎng,hòuláiyòutíchūqǐngtārènjiàoyùdūbànděngzhíwu,jūnbèixiàjìquánjùjué.
 1	日本	日本	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=rìběn|LTranslit=rìběn
@@ -4289,6 +4445,7 @@
 28	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s157
+# parallel_id = zhgsd/test157
 # text = 夏道镇是中国福建省南平市延平区下辖的一个镇。
 # translit = xiàdàozhènshìzhōngguófújiànshěngnánpíngshìyánpíngqūxiàxiádeyīgèzhèn.
 1	夏道	夏道	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=xiàdào|LTranslit=xiàdào
@@ -4309,6 +4466,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s158
+# parallel_id = zhgsd/test158
 # text = 夏须草属（学名：Theropogon）是百合科下的一个属，为多年生草本植物。
 # translit = xiàxūcǎoshǔ(xuémíng:Theropogon)shìbǎihékēxiàdeyīgèshǔ,wèiduōniánshēngcǎoběnzhíwù.
 1	夏须草	夏须草	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=xiàxūcǎo|LTranslit=xiàxūcǎo
@@ -4336,6 +4494,7 @@
 23	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s159
+# parallel_id = zhgsd/test159
 # text = 一般来说，制定外交政策是由政府首脑及外长负责。
 # translit = yībānláishuō,zhìdìngwàijiāozhèngcèshìyóuzhèngfǔshǒunǎojíwàizhǎngfùzé.
 1	一般	一般	ADJ	JJ	_	3	advmod	_	SpaceAfter=No|Translit=yībān|LTranslit=yībān
@@ -4355,6 +4514,7 @@
 15	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s160
+# parallel_id = zhgsd/test160
 # text = 这项设计主要是当人体或是金属物体碰触到触控式外出开关面板时，触控式外出开关会启动内部设计的NC接点切换到NC接点，门就会自动开启。
 # translit = zhèxiàngshèjìzhǔyàoshìdāngréntǐhuòshìjīnshǔwùtǐpèngchùdàochùkòngshìwàichūkāiguānmiànbǎnshí,chùkòngshìwàichūkāiguānhuìqǐdòngnèibùshèjìdeNCjiēdiǎnqièhuàndàoNCjiēdiǎn,ménjiùhuìzìdòngkāiqǐ.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -4400,6 +4560,7 @@
 41	。	。	PUNCT	.	_	40	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s161
+# parallel_id = zhgsd/test161
 # text = 科学家认为生命可能曾经存在过或者依然存在的地方包括金星、火星、木星的卫星（如木卫二、木卫六）、土星的卫星（如土卫六和土卫二）。
 # translit = kēxuéjiārènwèishēngmìngkěnéngcéngjīngcúnzàiguòhuòzhěyīráncúnzàidedefāngbāokuòjīnxīng,huǒxīng,mùxīngdewèixīng(rúmùwèi'èr,mùwèiliù),tǔxīngdewèixīng(rútǔwèiliùhétǔwèi'èr).
 1	科学	科学	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=kēxué|LTranslit=kēxué
@@ -4446,6 +4607,7 @@
 42	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s162
+# parallel_id = zhgsd/test162
 # text = 你可以应用这种逻辑系统作为模糊集合论的理论基础。
 # translit = nǐkěyǐyīngyòngzhèzhǒngluójixìtǒngzuòwèimóhujíhélùndelǐlùnjīchǔ.
 1	你	你	PRON	PRP	Person=2	3	nsubj	_	SpaceAfter=No|Translit=nǐ|LTranslit=nǐ
@@ -4466,6 +4628,7 @@
 16	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s163
+# parallel_id = zhgsd/test163
 # text = 多利纳是乌克兰的城市，位于该国西南部，距离伊万诺-弗兰科夫斯克州58公里，由伊万诺-弗兰科夫斯克州负责管辖，始建于979年，面积27平方公里，2011年人口20,453。
 # translit = duōlìnàshìwūkèlándechéngshì,wèiyúgāiguóxinánbù,jùlíyīwàn诺-fúlánkēfusīkèzhōu58gōnglǐ,yóuyīwàn诺-fúlánkēfusīkèzhōufùzéguǎnxiá,shǐjiànyú979nián,miànjī27píngfānggōnglǐ,2011niánrénkǒu20,453.
 1	多利纳	多利纳	PROPN	NNP	_	19	nsubj	_	SpaceAfter=No|Translit=duōlìnà|LTranslit=duōlìnà
@@ -4512,6 +4675,7 @@
 42	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s164
+# parallel_id = zhgsd/test164
 # text = MS也常见于欧洲北部族群分布区域，但是在这些MS常见的区域，某些种族群体发病风险较低。
 # translit = MSyěchángjiànyú'ōuzhōuběibùzúqúnfēnbùqūyù,dànshìzàizhèxiēMSchángjiàndeqūyù,mǒuxiēzhǒngzúqúntǐfābìngfēngxiǎnjiàodī.
 1	MS	MS	X	FW	Foreign=Yes	3	nsubj	_	SpaceAfter=No|Translit=MS|LTranslit=MS
@@ -4541,6 +4705,7 @@
 25	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s165
+# parallel_id = zhgsd/test165
 # text = 神经元传递信息，形成思维和感觉，以使大脑控制身体。
 # translit = shénjīngyuánchuándìxìnxi,xíngchéngsīwéihégǎnjué,yǐshǐdànǎokòngzhìshēntǐ.
 1	神经	神经	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=shénjīng|LTranslit=shénjīng
@@ -4561,6 +4726,7 @@
 16	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s166
+# parallel_id = zhgsd/test166
 # text = 杜笃玛属半干旱气候，全年气候相对温暖，全年平均降雨量约570毫米，降雨主要集中于12月至翌年3月的雨季，其他月份属相对干燥的旱季。
 # translit = dù笃mǎshǔbàngànhànqìhou,quánniánqìhouxiāngduìwēnnuǎn,quánniánpíngjūnjiàngyǔliàngyuē570háomǐ,jiàngyǔzhǔyàojízhōngyú12yuèzhì翌nián3yuèdeyǔjì,qítāyuèfènshǔxiāngduìgànzàodehànjì.
 1	杜笃玛	杜笃玛	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=dù笃mǎ|LTranslit=dù笃mǎ
@@ -4605,6 +4771,7 @@
 40	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s167
+# parallel_id = zhgsd/test167
 # text = 次日，近卫首相宣言“不以蒋中正为谈判对手”。
 # translit = cìrì,jìnwèishǒuxiāngxuānyán“bùyǐ蒋zhōngzhèngwèitánpànduìshǒu”.
 1	次日	次日	NOUN	NN	_	5	nmod:tmod	_	SpaceAfter=No|Translit=cìrì|LTranslit=cìrì
@@ -4624,6 +4791,7 @@
 15	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s168
+# parallel_id = zhgsd/test168
 # text = 结合起来的火箭称为运载火箭。
 # translit = jiéhéqǐláidehuǒjiànchēngwèiyùnzàihuǒjiàn.
 1	结合	结合	VERB	VV	_	4	acl:relcl	_	SpaceAfter=No|Translit=jiéhé|LTranslit=jiéhé
@@ -4637,6 +4805,7 @@
 9	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s169
+# parallel_id = zhgsd/test169
 # text = 此套电影引起了一位名叫马徐维邦的中国人兴趣，他把此电影拍成华语版，不单引起更大的轰动，而且更为中国电影史上第一部恐怖片。
 # translit = cǐtàodiànyǐngyǐnqǐleyīwèimíngjiàomǎxúwéibāngdezhōngguórénxìngqù,tābǎcǐdiànyǐngpāichénghuáyǔbǎn,bùdānyǐnqǐgèngdàdehōngdòng,'érqiěgèngwèizhōngguódiànyǐngshǐshàngdìyībùkǒngbùpiàn.
 1	此套	此套	DET	DT	_	2	det	_	SpaceAfter=No|Translit=cǐtào|LTranslit=cǐtào
@@ -4683,6 +4852,7 @@
 42	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s170
+# parallel_id = zhgsd/test170
 # text = 达哉的表姊，由于亲生父母夫妻不合且家庭乱七八糟的关系，于是在达哉父母的考量下被收养为养女。
 # translit = dá哉debiǎozǐ,yóuyúqīnshēngfùmǔfuqībùhéqiějiātíngluànqībāzāodeguānxì,yúshìzàidá哉fùmǔdekǎoliàngxiàbèishōuyǎngwèiyǎngnǚ.
 1	达哉	达哉	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=dá哉|LTranslit=dá哉
@@ -4714,6 +4884,7 @@
 27	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s171
+# parallel_id = zhgsd/test171
 # text = 2008年10月起，本作改编的动画开始在TBS系电视台放映。
 # translit = 2008nián10yuèqǐ,běnzuògǎibiāndedònghuàkāishǐzàiTBSxìdiànshìtáifàngyìng.
 1	2008	2008	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=2008|LTranslit=2008
@@ -4736,6 +4907,7 @@
 18	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s172
+# parallel_id = zhgsd/test172
 # text = 《夜行神龙》（Gargoyles）是美国迪士尼公司推出的动画影集，从1994年到1997年播出，共78集，每集30分钟（含广告的时间）。
 # translit = «yèxíngshénlóng»(Gargoyles)shìměiguódíshìnígōngsītuīchūdedònghuàyǐngjí,cóng1994niándào1997niánbōchū,gòng78jí,měijí30fēnzhōng(hánguǎnggàodeshíjiān).
 1	《	《	PUNCT	(	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -4778,6 +4950,7 @@
 38	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s173
+# parallel_id = zhgsd/test173
 # text = 他们也需保守有关他们关系的秘密，相较美朱在第一集跟鬼宿表白，这种关系显得比较成熟。
 # translit = tāmenyěxūbǎoshǒuyǒuguāntāmenguānxìdemìmì,xiāngjiàoměi朱zàidìyījígēnguǐsùbiǎobái,zhèzhǒngguānxìxiǎndebǐjiàochéngshú.
 1	他们	他	PRON	PRP	Number=Plur|Person=3	4	nsubj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -4808,6 +4981,7 @@
 26	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s174
+# parallel_id = zhgsd/test174
 # text = 头上发饰的皇冠就是宫廷蛋糕师的印记。
 # translit = tóushàngfāshìdehuángguānjiùshìgōngtíngdàngāoshīdeyìnjì.
 1	头上	头上	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=tóushàng|LTranslit=tóushàng
@@ -4823,6 +4997,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s175
+# parallel_id = zhgsd/test175
 # text = 秦月香为保护女儿采青误杀桑老三，被知县萧汝章利用，将月香的旧主子、采青生父青城富商沈渊卷入是非漩涡。
 # translit = 秦yuèxiāngwèibǎohùnǚrcǎiqīngwùshāsānglǎosān,bèizhīxiàn萧汝zhānglìyòng,jiāngyuèxiāngdejiùzhǔzi,cǎiqīngshēngfùqīngchéngfùshāng沈渊juǎnrùshìfēixuánwō.
 1	秦	秦	PROPN	NNP	_	15	nsubj:pass	_	SpaceAfter=No|Translit=秦|LTranslit=秦
@@ -4859,6 +5034,7 @@
 32	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s176
+# parallel_id = zhgsd/test176
 # text = 大义（1360年五月-十二月）是元朝时期陈友谅的年号，共计8个月。
 # translit = dàyì(1360niánwǔyuè-shí'èryuè)shìyuáncháoshíqīchényouliàngdeniánhào,gòngjì8gèyuè.
 1	大义	大义	PROPN	NNP	_	20	nsubj	_	SpaceAfter=No|Translit=dàyì|LTranslit=dàyì
@@ -4887,6 +5063,7 @@
 24	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s177
+# parallel_id = zhgsd/test177
 # text = 中国的塔什库尔干塔吉克自治县有波斯人聚居，流行波斯文化。
 # translit = zhōngguódetǎshénkù'ěrgàntǎjíkèzìzhìxiànyǒubōsīrénjùjū,liúxíngbōsīwénhuà.
 1	中国	中国	PROPN	NNP	_	5	nmod	_	SpaceAfter=No|Translit=zhōngguó|LTranslit=zhōngguó
@@ -4905,6 +5082,7 @@
 14	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s178
+# parallel_id = zhgsd/test178
 # text = 在前伊斯兰时期，伊朗人将他们的土地划分为两个主要部分，分别是伊朗及安勒尼兰（Aniran）。
 # translit = zàiqiányīsīlánshíqī,yīlǎngrénjiāngtāmendetǔdehuàfēnwèiliǎnggèzhǔyàobùfēn,fēnbiéshìyīlǎngjí'ānlēinílán(Aniran).
 1	在	在	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -4936,6 +5114,7 @@
 27	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s179
+# parallel_id = zhgsd/test179
 # text = 六年后的1956年3月8日，位于德国汉诺威新建成的福斯商用车工厂正式启用，原狼堡工厂停止生产福斯厢型车。
 # translit = liùniánhòude1956nián3yuè8rì,wèiyúdéguóhàn诺wēixīnjiànchéngdefúsīshāngyòngchēgōngchǎngzhèngshìqǐyòng,yuánlángbǎogōngchǎngtíngzhǐshēngchǎnfúsīxiāngxíngchē.
 1	六	六	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=liù|LTranslit=liù
@@ -4975,6 +5154,7 @@
 35	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s180
+# parallel_id = zhgsd/test180
 # text = 通过将原型的不断完善，其具有了更低的风阻系数、更佳的操控性和耐用度。
 # translit = tōngguòjiāngyuánxíngdebùduànwánshàn,qíjùyǒulegèngdīdefēngzǔxìshù,gèngjiādecāokòngxìnghénàiyòngdù.
 1	通过	通过	ADP	IN	_	6	case	_	SpaceAfter=No|Translit=tōngguò|LTranslit=tōngguò
@@ -5002,6 +5182,7 @@
 23	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s181
+# parallel_id = zhgsd/test181
 # text = 大佛口亦为湾仔区议会其中一个选区，现任议员为亲建制的民建联成员李匀颐。
 # translit = dàfúkǒuyìwèiwānzǐqūyìhuìqízhōngyīgèxuǎnqū,xiànrènyìyuánwèiqīnjiànzhìdemínjiànliánchéngyuánliyún颐.
 1	大佛	大佛	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=dàfú|LTranslit=dàfú
@@ -5028,6 +5209,7 @@
 22	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s182
+# parallel_id = zhgsd/test182
 # text = 大兴邨位于今天和平区桂林路与衡阳路之间的重庆道上，总建筑面积为5900平方米，其中占地面积为6100平方米。
 # translit = dàxìng邨wèiyújīntiānhépíngqū桂línlùyǔhéngyánglùzhījiāndezhòngqìngdàoshàng,zǒngjiànzhùmiànjīwèi5900píngfāngmǐ,qízhōngzhàndemiànjīwèi6100píngfāngmǐ.
 1	大兴	大兴	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=dàxìng|LTranslit=dàxìng
@@ -5064,6 +5246,7 @@
 32	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s183
+# parallel_id = zhgsd/test183
 # text = 大同宝宝是台湾的大同公司于1969年推出的吉祥物。
 # translit = dàtóngbǎobǎoshìtáiwāndedàtónggōngsīyú1969niántuīchūdejíxiángwù.
 1	大同	大同	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=dàtóng|LTranslit=dàtóng
@@ -5083,6 +5266,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s184
+# parallel_id = zhgsd/test184
 # text = 也就是说，该航程主要吸引美海军战斗机向大和攻击队迎战，缓和对日本特攻机的攻击。
 # translit = yějiùshìshuō,gāihángchéngzhǔyàoxīyǐnměihǎijūnzhàndòujīxiàngdàhégōngjīduìyíngzhàn,huǎnhéduìrìběntègōngjīdegōngjī.
 1	也	也	SCONJ	RB	_	3	mark	_	SpaceAfter=No|Translit=yě|LTranslit=yě
@@ -5113,6 +5297,7 @@
 26	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s185
+# parallel_id = zhgsd/test185
 # text = 在3月30日，美军军机在吴军港及广岛湾布置了1,034个水雷，由于需要时间清除水雷，所以令返回吴军港相当困难。
 # translit = zài3yuè30rì,měijūnjūnjīzài吴jūngǎngjíguǎngdǎowānbùzhìle1,034gèshuǐléi,yóuyúxūyàoshíjiānqīngchúshuǐléi,suǒyǐlìngfǎnhuí吴jūngǎngxiāngdāngkùnnán.
 1	在	在	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -5152,6 +5337,7 @@
 35	。	。	PUNCT	.	_	29	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s186
+# parallel_id = zhgsd/test186
 # text = 往返的航程中，第一炮塔因美军的轰炸而中了4枚炸弹，但对后续战斗没有影响。
 # translit = wǎngfǎndehángchéngzhōng,dìyīpàotǎyīnměijūndehōngzhà'érzhōngle4méizhàdàn,dànduìhòuxùzhàndòuméiyǒuyǐngxiǎng.
 1	往返	往返	VERB	VV	_	3	acl:relcl	_	SpaceAfter=No|Translit=wǎngfǎn|LTranslit=wǎngfǎn
@@ -5182,6 +5368,7 @@
 26	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s187
+# parallel_id = zhgsd/test187
 # text = 唯一出现的人类角色，也是养育大嘴鸟的人，角色原型是凡尔纳的小说环游世界八十天中名为“万事通”的助手。
 # translit = wéiyīchūxiànderénlèijiǎosè,yěshìyǎngyùdàzuǐniǎoderén,jiǎosèyuánxíngshìfán'ěrnàdexiǎoshuōhuányóushìjièbāshítiānzhōngmíngwèi“wànshìtōng”dezhùshǒu.
 1	唯一	唯一	ADJ	JJ	_	5	amod	_	SpaceAfter=No|Translit=wéiyī|LTranslit=wéiyī
@@ -5219,6 +5406,7 @@
 33	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s188
+# parallel_id = zhgsd/test188
 # text = 龙头由藤条屈曲为骨架；龙牙以锯齿的铁片造成；双眼是手电筒；舌头是漆红的木片。
 # translit = lóngtóuyóuténgtiáoqūqūwèigǔjià;lóngyáyǐjùchǐdetiěpiànzàochéng;shuāngyǎnshìshǒudiàntǒng;shétóushìqīhóngdemùpiàn.
 1	龙头	龙头	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=lóngtóu|LTranslit=lóngtóu
@@ -5249,6 +5437,7 @@
 26	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s189
+# parallel_id = zhgsd/test189
 # text = 在活动期间，该县被广东省文化厅授予广东省“汉乐之乡”称号。
 # translit = zàihuódòngqījiān,gāixiànbèiguǎngdōngshěngwénhuàtīngshòuyǔguǎngdōngshěng“hànlèzhīxiāng”chēnghào.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -5274,6 +5463,7 @@
 21	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s190
+# parallel_id = zhgsd/test190
 # text = 此作也被改编成真人电影、小说、动画等。
 # translit = cǐzuòyěbèigǎibiānchéngzhēnréndiànyǐng,xiǎoshuō,dònghuàděng.
 1	此作	此作	NOUN	NN	_	4	nsubj:pass	_	SpaceAfter=No|Translit=cǐzuò|LTranslit=cǐzuò
@@ -5291,6 +5481,7 @@
 13	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s191
+# parallel_id = zhgsd/test191
 # text = 大孔多孔菌，属多孔菌科一种，是木栖腐生的中小型菇类。
 # translit = dàkǒngduōkǒngjūn,shǔduōkǒngjūnkēyīzhǒng,shìmù栖fǔshēngdezhōngxiǎoxínggulèi.
 1	大孔多孔菌	大孔多孔菌	NOUN	NN	_	14	nsubj	_	SpaceAfter=No|Translit=dàkǒngduōkǒngjūn|LTranslit=dàkǒngduōkǒngjūn
@@ -5310,6 +5501,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s192
+# parallel_id = zhgsd/test192
 # text = 大安国际大楼是位于台湾台中市南区忠明南路上的一幢摩天大楼，楼高151.2米，共地上42层，地下4层。
 # translit = dà'ānguójìdàlóushìwèiyútáiwāntáizhōngshìnánqūzhōngmíngnánlùshàngdeyī幢mótiāndàlóu,lóugāo151.2mǐ,gòngdeshàng42céng,dexià4céng.
 1	大安	大安	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=dà'ān|LTranslit=dà'ān
@@ -5348,6 +5540,7 @@
 34	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s193
+# parallel_id = zhgsd/test193
 # text = 2005年12月，该剧在横店开机，除保留了原制作班底，主要演员全部更换。
 # translit = 2005nián12yuè,gāijùzàihéngdiànkāijī,chúbǎoliúleyuánzhìzuòbāndǐ,zhǔyàoyǎnyuánquánbùgènghuàn.
 1	2005	2005	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=2005|LTranslit=2005
@@ -5374,6 +5567,7 @@
 22	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s194
+# parallel_id = zhgsd/test194
 # text = 据媒体引述，共约1500名国立大学教员涉案，检调单位陆续约谈了其中约700人。
 # translit = jùméitǐyǐnshù,gòngyuē1500míngguólìdàxuéjiàoyuánshè'àn,jiǎndiàodānwèilùxùyuētánleqízhōngyuē700rén.
 1	据	据	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=jù|LTranslit=jù
@@ -5402,6 +5596,7 @@
 24	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s195
+# parallel_id = zhgsd/test195
 # text = 黄昏时，夕阳照在山脉上，石头反射着通红色，像着了火一样，蔚为奇观。
 # translit = huánghūnshí,xīyángzhàozàishānmàishàng,shítóufǎnshèzhetōnghóngsè,xiàngzhelehuǒyīyàng,蔚wèiqíguān.
 1	黄昏	黄昏	NOUN	NN	_	5	nmod:tmod	_	SpaceAfter=No|Translit=huánghūn|LTranslit=huánghūn
@@ -5431,6 +5626,7 @@
 25	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s196
+# parallel_id = zhgsd/test196
 # text = 最大振幅的大气潮产生于日间太阳辐射对对流层的水蒸气和平流层的臭氧周期性加热。
 # translit = zuìdàzhènfúdedàqìcháochǎnshēngyúrìjiāntàiyángfúshèduìduìliúcéngdeshuǐzhēngqìhépíngliúcéngdechòuyǎngzhōuqīxìngjiārè.
 1	最大	最大	ADJ	JJ	_	2	amod	_	SpaceAfter=No|Translit=zuìdà|LTranslit=zuìdà
@@ -5460,6 +5656,7 @@
 25	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s197
+# parallel_id = zhgsd/test197
 # text = 1949年之后，广州地区铁路运量逐年增大，广州铁路分局也对铁路及站场进行整体改造。
 # translit = 1949niánzhīhòu,guǎngzhōudeqūtiělùyùnliàngzhúniánzēngdà,guǎngzhōutiělùfēnjúyěduìtiělùjízhànchǎngjìnxíngzhěngtǐgǎizào.
 1	1949	1949	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1949|LTranslit=1949
@@ -5487,6 +5684,7 @@
 23	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s198
+# parallel_id = zhgsd/test198
 # text = 2011年7月21日，大津祐树和德国足球甲级联赛球队门兴格拉德巴赫签约三年。
 # translit = 2011nián7yuè21rì,dàjīn祐shùhédéguózúqiújiǎjíliánsàiqiúduìménxìnggélādébahèqiānyuēsānnián.
 1	2011	2011	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2011|LTranslit=2011
@@ -5511,6 +5709,7 @@
 20	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s199
+# parallel_id = zhgsd/test199
 # text = 这些人大量捕杀大海牛，吃它们的肉、用它们的皮来制造与修补船只。
 # translit = zhèxiēréndàliàngbǔshādàhǎiniú,chītāmenderòu,yòngtāmendepíláizhìzàoyǔxiūbǔchuánzhǐ.
 1	这些	这些	DET	DT	_	2	det	_	SpaceAfter=No|Translit=zhèxiē|LTranslit=zhèxiē
@@ -5536,6 +5735,7 @@
 21	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s200
+# parallel_id = zhgsd/test200
 # text = 2006年，桃园县政府结合蒋公行馆、角板山行馆、慈湖陵寝、大溪陵寝、慈湖雕塑纪念公园为“两蒋文化园区”。
 # translit = 2006nián,táoyuánxiànzhèngfǔjiéhé蒋gōngxíngguǎn,jiǎobǎnshānxíngguǎn,cíhúlíng寝,dàxīlíng寝,cíhúdiāosùjìniàngōngyuánwèi“liǎng蒋wénhuàyuánqū”.
 1	2006	2006	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2006|LTranslit=2006
@@ -5573,6 +5773,7 @@
 33	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s201
+# parallel_id = zhgsd/test201
 # text = 海域东北处有一岛屿名为塔门，形成连接大赤门的海域及连接大鹏湾的塔门口。
 # translit = hǎiyùdōngběichùyǒuyīdǎoyǔmíngwèitǎmén,xíngchéngliánjiēdàchìméndehǎiyùjíliánjiēdà鹏wāndetǎménkǒu.
 1	海域	海域	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=hǎiyù|LTranslit=hǎiyù
@@ -5601,6 +5802,7 @@
 24	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s202
+# parallel_id = zhgsd/test202
 # text = 车站建于1928年，有蒙宝铁路经过该站，现仅办理货运，不办理客运业务，车站及其上下行区间均未电气化。
 # translit = chēzhànjiànyú1928nián,yǒuméngbǎotiělùjīngguògāizhàn,xiànjǐnbànlǐhuòyùn,bùbànlǐkèyùnyèwu,chēzhànjíqíshàngxiàxíngqūjiānjūnwèidiànqìhuà.
 1	车站	车站	NOUN	NN	_	20	nsubj	_	SpaceAfter=No|Translit=chēzhàn|LTranslit=chēzhàn
@@ -5638,6 +5840,7 @@
 33	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s203
+# parallel_id = zhgsd/test203
 # text = 大石桥乡，是下辖的一个乡镇级行政单位。
 # translit = dàshíqiáoxiāng,shìxiàxiádeyīgèxiāngzhènjíxíngzhèngdānwèi.
 1	大石	大石	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=dàshí|LTranslit=dàshí
@@ -5656,6 +5859,7 @@
 14	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s204
+# parallel_id = zhgsd/test204
 # text = 大统华拥有四处物流中心，其中3处在大温哥华地区，1处在多伦多。
 # translit = dàtǒnghuáyōngyǒusìchùwùliúzhōngxīn,qízhōng3chùzàidàwēngēhuádeqū,1chùzàiduōlúnduō.
 1	大统华	大统华	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=dàtǒnghuá|LTranslit=dàtǒnghuá
@@ -5680,6 +5884,7 @@
 20	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s205
+# parallel_id = zhgsd/test205
 # text = 从此大统华便完全成为一间由加拿大资金经营的本地公司。
 # translit = cóngcǐdàtǒnghuábiànwánquánchéngwèiyījiānyóujiānádàzījīnjīngyíngdeběndegōngsī.
 1	从此	从此	ADV	RB	_	5	advmod	_	SpaceAfter=No|Translit=cóngcǐ|LTranslit=cóngcǐ
@@ -5700,6 +5905,7 @@
 16	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s206
+# parallel_id = zhgsd/test206
 # text = 1933年，李吟秋主持修建新桥，工程技术人员在加固护岸的同时还加大孔径使桥长增加约20余米。
 # translit = 1933nián,liyínqiūzhǔchíxiūjiànxīnqiáo,gōngchéngjìshùrényuánzàijiāgùhù'àndetóngshíháijiādàkǒngjìngshǐqiáozhǎngzēngjiāyuē20yúmǐ.
 1	1933	1933	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1933|LTranslit=1933
@@ -5731,6 +5937,7 @@
 27	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s207
+# parallel_id = zhgsd/test207
 # text = 这里的竞争不断，四位妻子不断去争夺丈夫对自己的注意和感情，虽然大太太的竞争没有这么多。
 # translit = zhèlǐdejìngzhēngbùduàn,sìwèiqīzibùduànqùzhēngduózhàngfuduìzìjǐdezhùyìhégǎnqíng,suīrándàtàitàidejìngzhēngméiyǒuzhèmeduō.
 1	这里	这里	PRON	PRD	_	3	det	_	SpaceAfter=No|Translit=zhèlǐ|LTranslit=zhèlǐ
@@ -5763,6 +5970,7 @@
 28	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s208
+# parallel_id = zhgsd/test208
 # text = 几天以后，总经理李俊英在四川路上也被枪杀。
 # translit = jǐtiānyǐhòu,zǒngjīnglǐli俊yīngzàisìchuānlùshàngyěbèiqiāngshā.
 1	几	几	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=jǐ|LTranslit=jǐ
@@ -5782,6 +5990,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s209
+# parallel_id = zhgsd/test209
 # text = 该报以旅沪美国侨民为主要读者对象，着重报道美国和其他西方侨民在中国的活动。
 # translit = gāibàoyǐlǚ沪měiguó侨mínwèizhǔyàodúzhěduìxiàng,zhezhòngbàodàoměiguóhéqítāxifāng侨mínzàizhōngguódehuódòng.
 1	该报	该报	NOUN	NN	_	12	nsubj	_	SpaceAfter=No|Translit=gāibào|LTranslit=gāibào
@@ -5809,6 +6018,7 @@
 23	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s210
+# parallel_id = zhgsd/test210
 # text = 在2007年，耶茨将大脚类归类于板龙类。
 # translit = zài2007nián,yé茨jiāngdàjiǎolèiguīlèiyúbǎnlónglèi.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -5826,6 +6036,7 @@
 13	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s211
+# parallel_id = zhgsd/test211
 # text = 大脚类包含大椎龙科与里奥哈龙科等科。
 # translit = dàjiǎolèibāohándà椎lóngkēyǔlǐ'àohālóngkēděngkē.
 1	大脚	大脚	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=dàjiǎo|LTranslit=dàjiǎo
@@ -5841,6 +6052,7 @@
 11	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s212
+# parallel_id = zhgsd/test212
 # text = 可自创主角或者选择游戏提供的两个虚拟的主角（一为葡萄牙籍，另一为西班牙籍）。
 # translit = kězìchuàngzhǔjiǎohuòzhěxuǎnzéyóuxìtígōngdeliǎnggèxūnǐdezhǔjiǎo(yīwèipútáoyájí,lìngyīwèixibānyájí).
 1	可	可	AUX	MD	_	2	aux	_	SpaceAfter=No|Translit=kě|LTranslit=kě
@@ -5871,6 +6083,7 @@
 26	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s213
+# parallel_id = zhgsd/test213
 # text = 大花蕙兰的生产地主要是日本，韩国和中国，澳洲及美国等。
 # translit = dàhuā蕙lándeshēngchǎndezhǔyàoshìrìběn,hánguóhézhōngguó,'àozhōujíměiguóděng.
 1	大花蕙兰	大花蕙兰	NOUN	NN	_	4	nmod	_	SpaceAfter=No|Translit=dàhuā蕙lán|LTranslit=dàhuā蕙lán
@@ -5892,6 +6105,7 @@
 17	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s214
+# parallel_id = zhgsd/test214
 # text = 她受到野生动物保护官的父亲的影响，使她也有很强的正义感。
 # translit = tāshòudàoyěshēngdòngwùbǎohùguāndefùqīndeyǐngxiǎng,shǐtāyěyǒuhěnqiángdezhèngyìgǎn.
 1	她	她	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -5916,6 +6130,7 @@
 20	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s215
+# parallel_id = zhgsd/test215
 # text = 另一种解释来自奥地利经济学派。
 # translit = lìngyīzhǒngjiěshìláizì'àodelìjīngjìxuépài.
 1	另	另	DET	DT	_	3	det	_	SpaceAfter=No|Translit=lìng|LTranslit=lìng
@@ -5930,6 +6145,7 @@
 10	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s216
+# parallel_id = zhgsd/test216
 # text = 这项分析否定了存贷的作用，提出了股本衰退的假设。
 # translit = zhèxiàngfēnxīfǒudìnglecún贷dezuòyòng,tíchūlegǔběnshuāituìdejiǎshè.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -5950,6 +6166,7 @@
 16	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s217
+# parallel_id = zhgsd/test217
 # text = 大葆台站投入使用时是房山线市区一端的终点站，在本站设有临1路公交车前往大兴线新宫站并设置虚拟换乘，以解决房山线无法与其他线路换乘问题。
 # translit = dà葆táizhàntóurùshǐyòngshíshìfángshānxiànshìqūyīduāndezhōngdiǎnzhàn,zàiběnzhànshèyǒulín1lùgōngjiāochēqiánwǎngdàxìngxiànxīngōngzhànbìngshèzhìxūnǐhuànchéng,yǐjiějuéfángshānxiànwúfǎyǔqítāxiànlùhuànchéngwèntí.
 1	大葆台	大葆台	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=dà葆tái|LTranslit=dà葆tái
@@ -5998,6 +6215,7 @@
 44	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s218
+# parallel_id = zhgsd/test218
 # text = Rize在当年的圣丹斯电影节首映。
 # translit = Rizezàidāngniándeshèngdānsīdiànyǐngjiéshǒuyìng.
 1	Rize	Rize	X	FW	Foreign=Yes	8	nsubj	_	SpaceAfter=No|Translit=Rize|LTranslit=Rize
@@ -6011,6 +6229,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s219
+# parallel_id = zhgsd/test219
 # text = 他也参与了Courtney Love新专辑的制作。
 # translit = tāyěcānyǔleCourtney Lovexīnzhuānjidezhìzuò.
 1	他	他	PRON	PRP	Person=3	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -6026,6 +6245,7 @@
 11	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s220
+# parallel_id = zhgsd/test220
 # text = 这场秀大量使用了各种影片技术，舞台布景中还包括了一面巨形LED萤幕墙。
 # translit = zhèchǎngxiùdàliàngshǐyònglegèzhǒngyǐngpiànjìshù,wǔtáibùjǐngzhōngháibāokuòleyīmiànjùxíngLEDyíngmùqiáng.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -6053,6 +6273,7 @@
 23	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s221
+# parallel_id = zhgsd/test221
 # text = 《纽约时报》认为本剧“深刻地揭示了现实生活中，野心与自省之间的无休止争斗”。
 # translit = «niǔyuēshíbào»rènwèiběnjù“shēnkèdejiēshìlexiànshíshēnghuózhōng,yěxīnyǔzìshěngzhījiāndewúxiūzhǐzhēngdòu”.
 1	《	《	PUNCT	(	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -6082,6 +6303,7 @@
 25	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s222
+# parallel_id = zhgsd/test222
 # text = 尽管本剧在收视率上并不理想（第一季全年收视排行第27名，第二季为第46名），但是并不妨碍本剧成为“艾美奖宠儿”。
 # translit = jǐnguǎnběnjùzàishōushìlǜshàngbìngbùlǐxiǎng(dìyījìquánniánshōushìpáixíngdì27míng,dì'èrjìwèidì46míng),dànshìbìngbùfáng'àiběnjùchéngwèi“'àiměijiǎng宠r”.
 1	尽管	尽管	ADP	IN	_	9	case	_	SpaceAfter=No|Translit=jǐnguǎn|LTranslit=jǐnguǎn
@@ -6124,6 +6346,7 @@
 38	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s223
+# parallel_id = zhgsd/test223
 # text = 迦陵舍利塔为松柏环绕，南面一棵松树，北面一棵柏树，松树和柏树的枝条向白塔生长，似乎是要伸手将白塔抱住，因此得名松柏抱塔。
 # translit = 迦língshělìtǎwèisōngbǎihuánrào,nánmiànyīkēsōngshù,běimiànyīkēbǎishù,sōngshùhébǎishùdezhītiáoxiàngbáitǎshēngzhǎng,shìhushìyàoshēnshǒujiāngbáitǎbàozhù,yīncǐdemíngsōngbǎibàotǎ.
 1	迦陵	迦陵	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=迦líng|LTranslit=迦líng
@@ -6167,6 +6390,7 @@
 39	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s224
+# parallel_id = zhgsd/test224
 # text = 1920年（大正九年）8月，泽田俊郎归国到仙台结婚，后偕新婚妻子再度回到满洲。
 # translit = 1920nián(dàzhèngjiǔnián)8yuè,泽tián俊郎guīguódàoxiantáijiéhūn,hòu偕xīnhūnqīzizàidùhuídàomǎnzhōu.
 1	1920	1920	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1920|LTranslit=1920
@@ -6196,6 +6420,7 @@
 25	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s225
+# parallel_id = zhgsd/test225
 # text = 1921年（大正十年）6月，泽田俊郎的长男在满洲出生。
 # translit = 1921nián(dàzhèngshínián)6yuè,泽tián俊郎dezhǎngnánzàimǎnzhōuchūshēng.
 1	1921	1921	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1921|LTranslit=1921
@@ -6218,6 +6443,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s226
+# parallel_id = zhgsd/test226
 # text = 哥特式建筑，位于中山路和玉光街之间。
 # translit = gētèshìjiànzhù,wèiyúzhōngshānlùhéyùguāngjiēzhījiān.
 1	哥特	哥特	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=gētè|LTranslit=gētè
@@ -6235,6 +6461,7 @@
 13	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s227
+# parallel_id = zhgsd/test227
 # text = 最终沙俄战败，规划未能实现。
 # translit = zuìzhōngshā'ézhànbài,guīhuàwèinéngshíxiàn.
 1	最终	最终	NOUN	NN	_	3	nmod:tmod	_	SpaceAfter=No|Translit=zuìzhōng|LTranslit=zuìzhōng
@@ -6247,6 +6474,7 @@
 8	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s228
+# parallel_id = zhgsd/test228
 # text = 同年，该公司宣布，自2006年1月1日起大幅削减对全国的退休人员的卫生保健开销。
 # translit = tóngnián,gāigōngsīxuānbù,zì2006nián1yuè1rìqǐdàfúxuējiǎnduìquánguódetuìxiūrényuándewèishēngbǎojiànkāixiāo.
 1	同年	同年	NOUN	NN	_	5	nmod:tmod	_	SpaceAfter=No|Translit=tóngnián|LTranslit=tóngnián
@@ -6277,6 +6505,7 @@
 26	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s229
+# parallel_id = zhgsd/test229
 # text = 该公司总部设在德国汉诺威。
 # translit = gāigōngsīzǒngbùshèzàidéguóhàn诺wēi.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -6289,6 +6518,7 @@
 8	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s230
+# parallel_id = zhgsd/test230
 # text = 《大雄的宇宙开拓史》，是藤子·F·不二雄执笔，于1980年9月号到1981年2月连载于《快乐快乐月刊》月刊，是《哆啦A梦》大长篇的一部分。
 # translit = «dàxióngdeyǔzhòukāi拓shǐ»,shìténgzi·F·bù'èrxióngzhíbǐ,yú1980nián9yuèhàodào1981nián2yuèliánzàiyú«kuàilèkuàilèyuèkān»yuèkān,shì«duōlaAmèng»dàzhǎngpiāndeyībùfēn.
 1	《	《	PUNCT	(	_	6	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -6339,6 +6569,7 @@
 46	。	。	PUNCT	.	_	45	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s231
+# parallel_id = zhgsd/test231
 # text = 3月1日在为高宗举行国葬时，韩国民众借机在各地游行，韩国独立运动者在京城塔洞公园发表了独立宣言，要求韩国独立，是为“三一运动”。
 # translit = 3yuè1rìzàiwèigāozōngjǔxíngguózàngshí,hánguómínzhòngjièjīzàigèdeyóuxíng,hánguódúlìyùndòngzhězàijīngchéngtǎdònggōngyuánfābiǎoledúlìxuānyán,yàoqiúhánguódúlì,shìwèi“sānyīyùndòng”.
 1	3	3	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=3|LTranslit=3
@@ -6385,6 +6616,7 @@
 42	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s232
+# parallel_id = zhgsd/test232
 # text = 朝韩分治后，大韩民国经历了民主与独裁统治的反复交替。
 # translit = cháohánfēnzhìhòu,dàhánmínguójīnglìlemínzhǔyǔdúcáitǒngzhìdefǎnfùjiāotì.
 1	朝	朝	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit=cháo|LTranslit=cháo
@@ -6406,6 +6638,7 @@
 17	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s233
+# parallel_id = zhgsd/test233
 # text = 韩国气候受东韩暖流影响，气候相对温暖湿润，与日本气候相似。
 # translit = hánguóqìhoushòudōnghánnuǎnliúyǐngxiǎng,qìhouxiāngduìwēnnuǎnshīrùn,yǔrìběnqìhouxiāngshì.
 1	韩国	韩国	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=hánguó|LTranslit=hánguó
@@ -6428,6 +6661,7 @@
 18	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s234
+# parallel_id = zhgsd/test234
 # text = 大额蛇鳗，为辐鳍鱼纲鳗鲡目糯鳗亚目蛇鳗科的其中一种，分布于中东太平洋区，从加利福尼亚湾中部至巴拿马海域，栖息深度35-760公尺，体长可达86公分，栖息在沙泥底质海域，为底栖性鱼类，属肉食性，生活习性不明。
 # translit = dà'éshé鳗,wèifú鳍yúgāng鳗鲡mù糯鳗yàmùshé鳗kēdeqízhōngyīzhǒng,fēnbùyúzhōngdōngtàipíngyángqū,cóngjiālìfúníyàwānzhōngbùzhìbanámǎhǎiyù,栖xishēndù35-760gōngchǐ,tǐzhǎngkědá86gōngfēn,栖xizàishānídǐzhìhǎiyù,wèidǐ栖xìngyúlèi,shǔròushíxìng,shēnghuóxíxìngbùmíng.
 1	大额蛇鳗	大额蛇鳗	NOUN	NN	_	17	nsubj	_	SpaceAfter=No|Translit=dà'éshé鳗|LTranslit=dà'éshé鳗
@@ -6495,6 +6729,7 @@
 63	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s235
+# parallel_id = zhgsd/test235
 # text = 2010年有教友54,942人、廿一个堂区、廿九名司铎。
 # translit = 2010niányǒujiàoyou54,942rén,niànyīgètángqū,niànjiǔmíngsī铎.
 1	2010	2010	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2010|LTranslit=2010
@@ -6514,6 +6749,7 @@
 15	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s236
+# parallel_id = zhgsd/test236
 # text = 教区成立于1956年12月17日，包括兰巴耶克大区和卡哈马卡大区的圣克鲁斯省。
 # translit = jiàoqūchénglìyú1956nián12yuè17rì,bāokuòlánbayékèdàqūhékǎhāmǎkǎdàqūdeshèngkèlǔsīshěng.
 1	教区	教区	NOUN	NN	_	11	nsubj	_	SpaceAfter=No|Translit=jiàoqū|LTranslit=jiàoqū
@@ -6538,6 +6774,7 @@
 20	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s237
+# parallel_id = zhgsd/test237
 # text = 天主教安国教区是中国第一批6个国籍教区中教友人数较多的一个。
 # translit = tiānzhǔjiào'ānguójiàoqūshìzhōngguódìyīpī6gèguójíjiàoqūzhōngjiàoyourénshùjiàoduōdeyīgè.
 1	天主	天主	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=tiānzhǔ|LTranslit=tiānzhǔ
@@ -6562,6 +6799,7 @@
 20	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s238
+# parallel_id = zhgsd/test238
 # text = 教长区成立于1951年11月14日，1997年有教友10,000人、四个堂区、五名司铎。
 # translit = jiàozhǎngqūchénglìyú1951nián11yuè14rì,1997niányǒujiàoyou10,000rén,sìgètángqū,wǔmíngsī铎.
 1	教长	教长	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=jiàozhǎng|LTranslit=jiàozhǎng
@@ -6592,6 +6830,7 @@
 26	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s239
+# parallel_id = zhgsd/test239
 # text = 教区下辖七十四个堂区，有八十七名司铎。
 # translit = jiàoqūxiàxiáqīshísìgètángqū,yǒubāshíqīmíngsī铎.
 1	教区	教区	NOUN	NN	_	7	nsubj	_	SpaceAfter=No|Translit=jiàoqū|LTranslit=jiàoqū
@@ -6607,6 +6846,7 @@
 11	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s240
+# parallel_id = zhgsd/test240
 # text = 现任主教为朱斯廷·苏敏德。
 # translit = xiànrènzhǔjiàowèi朱sītíng·sūmǐndé.
 1	现任	现任	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=xiànrèn|LTranslit=xiànrèn
@@ -6618,6 +6858,7 @@
 7	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s241
+# parallel_id = zhgsd/test241
 # text = 1815年，嘉庆皇帝强化禁教，将法国籍主教徐德新等11名传教士，斩首于成都，并悬头于城门三日。
 # translit = 1815nián,jiāqìnghuángdìqiánghuàjìnjiào,jiāngfǎguójízhǔjiàoxúdéxīnděng11míngchuánjiàoshì,斩shǒuyúchéngdōu,bìngxuántóuyúchéngménsānrì.
 1	1815	1815	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1815|LTranslit=1815
@@ -6652,6 +6893,7 @@
 30	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s242
+# parallel_id = zhgsd/test242
 # text = 教区下辖218个堂区，有327名司铎。
 # translit = jiàoqūxiàxiá218gètángqū,yǒu327míngsī铎.
 1	教区	教区	NOUN	NN	_	7	nsubj	_	SpaceAfter=No|Translit=jiàoqū|LTranslit=jiàoqū
@@ -6667,6 +6909,7 @@
 11	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s243
+# parallel_id = zhgsd/test243
 # text = 教区成立于2013年2月22日，范围包括高原省。
 # translit = jiàoqūchénglìyú2013nián2yuè22rì,fànwéibāokuògāoyuánshěng.
 1	教区	教区	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=jiàoqū|LTranslit=jiàoqū
@@ -6686,6 +6929,7 @@
 15	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s244
+# parallel_id = zhgsd/test244
 # text = 教区成立于1969年7月18日，位于布宜诺斯艾利斯省马坦萨县。
 # translit = jiàoqūchénglìyú1969nián7yuè18rì,wèiyúbùyi诺sī'àilìsīshěngmǎtǎnsàxiàn.
 1	教区	教区	NOUN	NN	_	11	nsubj	_	SpaceAfter=No|Translit=jiàoqū|LTranslit=jiàoqū
@@ -6707,6 +6951,7 @@
 17	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s245
+# parallel_id = zhgsd/test245
 # text = 中国有35属约206种，主要分布在南方各地。
 # translit = zhōngguóyǒu35shǔyuē206zhǒng,zhǔyàofēnbùzàinánfānggède.
 1	中国	中国	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=zhōngguó|LTranslit=zhōngguó
@@ -6725,6 +6970,7 @@
 14	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s246
+# parallel_id = zhgsd/test246
 # text = 那座天后庙位于天后庙道，建于1747年。
 # translit = nàzuòtiānhòumiàowèiyútiānhòumiàodào,jiànyú1747nián.
 1	那	那	DET	DT	_	2	det	_	SpaceAfter=No|Translit=nà|LTranslit=nà
@@ -6744,6 +6990,7 @@
 15	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s247
+# parallel_id = zhgsd/test247
 # text = 和其他动作作品中敌人的破坏不同，《天地创造》引入了创造主题，这也激发玩家想像他们行动可能带来的效果。
 # translit = héqítādòngzuòzuòpǐnzhōngdíréndepòhuàibùtóng,«tiāndechuàngzào»yǐnrùlechuàngzàozhǔtí,zhèyějīfāwánjiāxiǎngxiàngtāmenxíngdòngkěnéngdàiláidexiàoguǒ.
 1	和	和	ADP	IN	_	8	case	_	SpaceAfter=No|Translit=hé|LTranslit=hé
@@ -6779,6 +7026,7 @@
 31	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s248
+# parallel_id = zhgsd/test248
 # text = 在植物的帮助下，阿空穿过了基亚那山。
 # translit = zàizhíwùdebāngzhùxià,'ākōngchuānguòlejīyànàshān.
 1	在	在	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -6795,6 +7043,7 @@
 12	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s249
+# parallel_id = zhgsd/test249
 # text = 游戏世界以俯视视角显示，并使用动作制即时战斗系统，通过跑动、跳跃、攻击，或将这些动作结合，玩家可使用不同的技能。
 # translit = yóuxìshìjièyǐfǔshìshìjiǎoxiǎnshì,bìngshǐyòngdòngzuòzhìjíshízhàndòuxìtǒng,tōngguòpǎodòng,tiàoyuè,gōngjī,huòjiāngzhèxiēdòngzuòjiéhé,wánjiākěshǐyòngbùtóngdejìnéng.
 1	游戏	游戏	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=yóuxì|LTranslit=yóuxì
@@ -6834,6 +7083,7 @@
 35	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s250
+# parallel_id = zhgsd/test250
 # text = 因为非常有威严，往往一般认为她是园长。
 # translit = yīnwèifēichángyǒuwēiyán,wǎngwǎngyībānrènwèitāshìyuánzhǎng.
 1	因为	因为	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -6850,6 +7100,7 @@
 12	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s251
+# parallel_id = zhgsd/test251
 # text = 添和李护士怀疑郑明有宝物私藏着，乃引诱他吐露宝物所在。
 # translit = tiānhélihùshìhuáiyízhèngmíngyǒubǎowùsīcángzhe,nǎiyǐnyòutātǔlùbǎowùsuǒzài.
 1	添	添	PROPN	NNP	_	14	nsubj	_	SpaceAfter=No|Translit=tiān|LTranslit=tiān
@@ -6874,6 +7125,7 @@
 20	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s252
+# parallel_id = zhgsd/test252
 # text = 界人曾说过很喜欢她出的谜题。
 # translit = jièréncéngshuōguòhěnxǐhuantāchūde谜tí.
 1	界人	界人	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit=jièrén|LTranslit=jièrén
@@ -6889,6 +7141,7 @@
 11	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s253
+# parallel_id = zhgsd/test253
 # text = 每出一题，探长会指定任一参赛者回答该题，答对者加50分。
 # translit = měichūyītí,tànzhǎnghuìzhǐdìngrènyīcānsàizhěhuídágāití,dáduìzhějiā50fēn.
 1	每	每	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=měi|LTranslit=měi
@@ -6914,6 +7167,7 @@
 21	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s254
+# parallel_id = zhgsd/test254
 # text = 每集统计两队总分，总分最高者即是该集的优胜队，优胜队队员各获得同一个奖品。
 # translit = měijítǒngjìliǎngduìzǒngfēn,zǒngfēnzuìgāozhějíshìgāijídeyōushèngduì,yōushèngduìduìyuángèhuòdetóngyīgèjiǎngpǐn.
 1	每集	每集	DET	DT	_	2	obl	_	SpaceAfter=No|Translit=měijí|LTranslit=měijí
@@ -6944,6 +7198,7 @@
 26	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s255
+# parallel_id = zhgsd/test255
 # text = 这和世界上其他的编号系统有所差异。
 # translit = zhèhéshìjièshàngqítādebiānhàoxìtǒngyǒusuǒchàyì.
 1	这	这	PRON	PRD	_	9	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -6960,6 +7215,7 @@
 12	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s256
+# parallel_id = zhgsd/test256
 # text = 河长176千米，流域面积3700平方千米，年均流量11立方米每秒。
 # translit = hézhǎng176qiānmǐ,liúyùmiànjī3700píngfāngqiānmǐ,niánjūnliúliàng11lìfāngmǐměimiǎo.
 1	河	河	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=hé|LTranslit=hé
@@ -6979,6 +7235,7 @@
 15	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s257
+# parallel_id = zhgsd/test257
 # text = 到了2004年5月，天水围北唯一私人屋苑慧景轩正式入伙。
 # translit = dàole2004nián5yuè,tiānshuǐwéiběiwéiyīsīrénwū苑huìjǐng轩zhèngshìrùhuǒ.
 1	到	到	VERB	VV	_	17	advcl	_	SpaceAfter=No|Translit=dào|LTranslit=dào
@@ -7001,6 +7258,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s258
+# parallel_id = zhgsd/test258
 # text = 为营造新一代新市镇形象，当年所规划屋邨均设有大量休憩用地，并且设有少量预留空间作日后发展。
 # translit = wèiyíngzàoxīnyīdàixīnshìzhènxíngxiàng,dāngniánsuǒguīhuàwū邨jūnshèyǒudàliàngxiū憩yòngde,bìngqiěshèyǒushǎoliàngyùliúkōngjiānzuòrìhòufāzhǎn.
 1	为	为	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -7033,6 +7291,7 @@
 28	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s259
+# parallel_id = zhgsd/test259
 # text = 天津利顺德大饭店是天津市历史上第一家外资大饭店，在近代史上曾是重要的外交活动场所，英国、美国、加拿大、日本等国家曾先后将领事馆设于酒店内。
 # translit = tiānjīnlìshùndédàfàndiànshìtiānjīnshìlìshǐshàngdìyījiāwàizīdàfàndiàn,zàijìndàishǐshàngcéngshìzhòngyàodewàijiāohuódòngchǎngsuǒ,yīngguó,měiguó,jiānádà,rìběnděngguójiācéngxiānhòujiānglǐngshìguǎnshèyújiǔdiànnèi.
 1	天津	天津	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=tiānjīn|LTranslit=tiānjīn
@@ -7083,6 +7342,7 @@
 46	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s260
+# parallel_id = zhgsd/test260
 # text = 根据天津市地域内的地貌、气候、土壤、植被等的自然条件的差异，以满足城市需求为目标天津市的农业可分为都市型、滨海型和城郊型，据此天津市域的农业区划可以划分为都市型环城农业区、都市型滨海农业区、城郊型平原综合农业区和城郊型山区生态农业区四个农业区划。
 # translit = gēnjùtiānjīnshìdeyùnèidedemào,qìhou,tǔrǎng,zhíbèiděngdezìrántiáojiàndechàyì,yǐmǎnzúchéngshìxūqiúwèimùbiāotiānjīnshìdenóngyèkěfēnwèidōushìxíng,bīnhǎixínghéchéngjiāoxíng,jùcǐtiānjīnshìyùdenóngyèqūhuàkěyǐhuàfēnwèidōushìxínghuánchéngnóngyèqū,dōushìxíngbīnhǎinóngyèqū,chéngjiāoxíngpíngyuánzōnghénóngyèqūhéchéngjiāoxíngshānqūshēngtàinóngyèqūsìgènóngyèqūhuà.
 1	根据	根据	ADP	IN	_	19	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -7168,6 +7428,7 @@
 81	。	。	PUNCT	.	_	32	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s261
+# parallel_id = zhgsd/test261
 # text = 除此之外，天津市河东区还管辖位于河北省涉县的一块飞地，即天津铁厂街道。
 # translit = chúcǐzhīwài,tiānjīnshìhédōngqūháiguǎnxiáwèiyúhéběishěngshèxiàndeyīkuàifēide,jítiānjīntiěchǎngjiēdào.
 1	除此	除此	VERB	VV	_	9	advcl	_	SpaceAfter=No|Translit=chúcǐ|LTranslit=chúcǐ
@@ -7196,6 +7457,7 @@
 24	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s262
+# parallel_id = zhgsd/test262
 # text = 天津市人民政府驻乌鲁木齐办事处，是中华人民共和国天津市人民政府驻乌鲁木齐市的办事处，该办事处负责领导联络协调、招商引资、信息调研、对外宣传、接待服务以及服务驻乌鲁木齐市天津企业等相关事项。
 # translit = tiānjīnshìrénmínzhèngfǔzhùwūlǔmùqíbànshìchù,shìzhōnghuárénmíngònghéguótiānjīnshìrénmínzhèngfǔzhùwūlǔmùqíshìdebànshìchù,gāibànshìchùfùzélǐngdǎoliánluòxiédiào,zhāoshāngyǐnzī,xìnxidiàoyán,duìwàixuānchuán,jiēdàifúwuyǐjífúwuzhùwūlǔmùqíshìtiānjīnqǐyèděngxiāngguānshìxiàng.
 1	天津	天津	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=tiānjīn|LTranslit=tiānjīn
@@ -7255,6 +7517,7 @@
 55	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s263
+# parallel_id = zhgsd/test263
 # text = 历史上，1982年11月至1994年10月期间，天津市人民政府建立了驻福州和驻厦门办事处。
 # translit = lìshǐshàng,1982nián11yuèzhì1994nián10yuèqījiān,tiānjīnshìrénmínzhèngfǔjiànlìlezhùfúzhōuhézhùshàménbànshìchù.
 1	历史	历史	NOUN	NN	_	19	obl	_	SpaceAfter=No|Translit=lìshǐ|LTranslit=lìshǐ
@@ -7287,6 +7550,7 @@
 28	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s264
+# parallel_id = zhgsd/test264
 # text = 1919年扩建东厂后，年产量可达6万2千多吨。
 # translit = 1919niánkuòjiàndōngchǎnghòu,niánchǎnliàngkědá6wàn2qiānduōdūn.
 1	1919	1919	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1919|LTranslit=1919
@@ -7304,6 +7568,7 @@
 13	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s265
+# parallel_id = zhgsd/test265
 # text = 1959年3月13日，永久沽厂改为隶属于河北省化学石油工业厅。
 # translit = 1959nián3yuè13rì,yǒngjiǔ沽chǎnggǎiwèilìshǔyúhéběishěnghuàxuéshíyóugōngyètīng.
 1	1959	1959	NUM	CD	NumType=Card	2	nmod	_	SpaceAfter=No|Translit=1959|LTranslit=1959
@@ -7328,6 +7593,7 @@
 20	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s266
+# parallel_id = zhgsd/test266
 # text = 参赛者于前三个提示可以允许失误。
 # translit = cānsàizhěyúqiánsāngètíshìkěyǐyǔnxǔshīwù.
 1	参赛	参赛	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=cānsài|LTranslit=cānsài
@@ -7343,6 +7609,7 @@
 11	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s267
+# parallel_id = zhgsd/test267
 # text = 伟是一名国军空军飞行少尉，是来自于一个显赫家族的二少爷。
 # translit = wěishìyīmíngguójūnkōngjūnfēixíngshǎo尉,shìláizìyúyīgèxiǎnhèjiāzúde'èrshǎoye.
 1	伟	伟	PROPN	NNP	_	20	nsubj	_	SpaceAfter=No|Translit=wěi|LTranslit=wěi
@@ -7368,6 +7635,7 @@
 21	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s268
+# parallel_id = zhgsd/test268
 # text = 它们身体的颜色非常显目，雄性为蓝色，雌性则为绿色。
 # translit = tāmenshēntǐdeyánsèfēichángxiǎnmù,xióngxìngwèilánsè,cíxìngzéwèilǜsè.
 1	它们	它	PRON	PRP	Number=Plur|Person=3	2	nmod	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -7388,6 +7656,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s269
+# parallel_id = zhgsd/test269
 # text = 因发展迅速，众多支派经几番整合于西元1988年正式成立社会团体“中华民国一贯道总会”，同时向台湾政府登记为“一贯道”。
 # translit = yīnfāzhǎnxùnsù,zhòngduōzhīpàijīngjǐfānzhěnghéyúxiyuán1988niánzhèngshìchénglìshèhuìtuántǐ“zhōnghuámínguóyīguàndàozǒnghuì”,tóngshíxiàngtáiwānzhèngfǔdēngjìwèi“yīguàndào”.
 1	因	因	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=yīn|LTranslit=yīn
@@ -7429,6 +7698,7 @@
 37	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s270
+# parallel_id = zhgsd/test270
 # text = 他也写了许多给管乐团的曲目，其作品有被东京佼成管乐团选作录音。
 # translit = tāyěxiělexǔduōgěiguǎnlètuándeqūmù,qízuòpǐnyǒubèidōngjīng佼chéngguǎnlètuánxuǎnzuòlùyīn.
 1	他	他	PRON	PRP	Person=3	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -7453,6 +7723,7 @@
 20	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s271
+# parallel_id = zhgsd/test271
 # text = 观景台于2011年4月17日起试业，开放时间为早上10时至晚上8时半。
 # translit = guānjǐngtáiyú2011nián4yuè17rìqǐshìyè,kāifàngshíjiānwèizǎoshàng10shízhìwǎnshàng8shíbàn.
 1	观景	观景	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=guānjǐng|LTranslit=guānjǐng
@@ -7481,6 +7752,7 @@
 24	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s272
+# parallel_id = zhgsd/test272
 # text = 这个时代的天皇是近卫天皇。
 # translit = zhègèshídàidetiānhuángshìjìnwèitiānhuáng.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -7494,6 +7766,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s273
+# parallel_id = zhgsd/test273
 # text = 此时，真正的中情局要员林奇把叛变的林奇带走了。
 # translit = cǐshí,zhēnzhèngdezhōngqíngjúyàoyuánlínqíbǎpànbiàndelínqídàizǒule.
 1	此时	此时	NOUN	NN	_	15	nmod:tmod	_	SpaceAfter=No|Translit=cǐshí|LTranslit=cǐshí
@@ -7515,6 +7788,7 @@
 17	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s274
+# parallel_id = zhgsd/test274
 # text = 太平公主号的理赔问题等将交由保险公司、船公司与香港方面处理。
 # translit = tàipínggōngzhǔhàodelǐpéiwèntíděngjiāngjiāoyóubǎoxiǎngōngsī,chuángōngsīyǔxiānggǎngfāngmiànchùlǐ.
 1	太平	太平	PROPN	NNP	_	3	compound	_	SpaceAfter=No|Translit=tàipíng|LTranslit=tàipíng
@@ -7539,6 +7813,7 @@
 20	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s275
+# parallel_id = zhgsd/test275
 # text = 1939年4月，日军攻占太平岛，并将其更名为长岛，纳入高雄州管理。
 # translit = 1939nián4yuè,rìjūngōngzhàntàipíngdǎo,bìngjiāngqígèngmíngwèizhǎngdǎo,nàrùgāoxióngzhōuguǎnlǐ.
 1	1939	1939	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1939|LTranslit=1939
@@ -7566,6 +7841,7 @@
 23	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s276
+# parallel_id = zhgsd/test276
 # text = 在岛西南方的防波堤末端竖立起“太平岛”石碑，并在岛之东端，另立“南沙群岛太平岛”石碑。
 # translit = zàidǎoxinánfāngdefángbōdīmòduānshùlìqǐ“tàipíngdǎo”shíbēi,bìngzàidǎozhīdōngduān,lìnglì“nánshāqúndǎotàipíngdǎo”shíbēi.
 1	在	在	VERB	VV	_	9	advcl	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -7601,6 +7877,7 @@
 31	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s277
+# parallel_id = zhgsd/test277
 # text = 本岛东部有一片热带海岸林，其树高可达20公尺，主要以檄树、榄仁树、莲叶桐、葛塔德木、草海桐、白水木、海柠檬、藤蟛蜞菊、长柄菊、长鞍藤、葛蕾草等乔木为主，林间杂有林投、可可椰子。
 # translit = běndǎodōngbùyǒuyīpiànrèdàihǎi'ànlín,qíshùgāokědá20gōngchǐ,zhǔyàoyǐ檄shù,榄rénshù,莲yè桐,葛tǎdémù,cǎohǎi桐,báishuǐmù,hǎi柠檬,téng蟛蜞jú,zhǎngbǐngjú,zhǎng鞍téng,葛蕾cǎoděng乔mùwèizhǔ,línjiānzáyǒulíntóu,kěkě椰zi.
 1	本岛	本岛	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=běndǎo|LTranslit=běndǎo
@@ -7655,6 +7932,7 @@
 50	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s278
+# parallel_id = zhgsd/test278
 # text = 他对澳大利亚报纸谈到：“与其在无核议题这种遗物上试图说服对方，不如把精力集中于我们能够合作的事情上。”
 # translit = tāduì'àodàlìyàbàozhǐtándào:“yǔqízàiwúhéyìtízhèzhǒngyíwùshàngshìtúshuōfúduìfāng,bùrúbǎjīnglìjízhōngyúwǒmennénggòuhézuòdeshìqíngshàng.”
 1	他	他	PRON	PRP	Person=3	5	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -7691,6 +7969,7 @@
 32	”	”	PUNCT	''	_	20	punct	_	SpaceAfter=No|Translit=”|LTranslit=”
 
 # sent_id = test-s279
+# parallel_id = zhgsd/test279
 # text = 在此条约之下的美澳同盟仍然完全有效，两国的国防部长经常列席年度部长级会议，美国太平洋地区总司令和澳洲参谋总长也常进行咨商，美国国务卿和澳洲外交部长每年会就条约相关事务进行会议，第17届部长级会议在2005年11月澳洲阿德莱德召开。
 # translit = zàicǐtiáoyuēzhīxiàdeměi'àotóngméngréngránwánquányǒuxiào,liǎngguódeguófángbùzhǎngjīngchánglièxíniándùbùzhǎngjíhuìyì,měiguótàipíngyángdeqūzǒngsīlìnghé'àozhōucānmóuzǒngzhǎngyěchángjìnxíng咨shāng,měiguóguówu卿hé'àozhōuwàijiāobùzhǎngměiniánhuìjiùtiáoyuēxiāngguānshìwujìnxínghuìyì,dì17jièbùzhǎngjíhuìyìzài2005nián11yuè'àozhōu'ādé莱dézhàokāi.
 1	在	在	ADP	IN	_	8	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -7763,6 +8042,7 @@
 68	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s280
+# parallel_id = zhgsd/test280
 # text = 根据1984年大选前的民意调查，百分之五十八的民众明确反对美国军舰的访问。
 # translit = gēnjù1984niándàxuǎnqiándemínyìdiàochá,bǎifēnzhīwǔshíbādemínzhòngmíngquèfǎnduìměiguójūnjiàndefǎngwèn.
 1	根据	根据	ADP	IN	_	8	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -7786,6 +8066,7 @@
 19	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s281
+# parallel_id = zhgsd/test281
 # text = 许多美国报纸因此在几周内都以头条批评美国内阁成员出卖盟友。
 # translit = xǔduōměiguóbàozhǐyīncǐzàijǐzhōunèidōuyǐtóutiáopīpíngměiguónèi阁chéngyuánchūmàiméngyou.
 1	许多	许多	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=xǔduō|LTranslit=xǔduō
@@ -7809,6 +8090,7 @@
 19	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s282
+# parallel_id = zhgsd/test282
 # text = 但是在本剧后半有关观应之乱等故事，则是吉川原作没有的创作。
 # translit = dànshìzàiběnjùhòubànyǒuguānguānyīngzhīluànděnggùshì,zéshìjíchuānyuánzuòméiyǒudechuàngzuò.
 1	但是	但是	SCONJ	RB	_	17	mark	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -7831,6 +8113,7 @@
 18	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s283
+# parallel_id = zhgsd/test283
 # text = 太平里乡原属湖南省宜章县下辖乡，2012年4月撤销，与沙坪乡一起成建制合并至新设的五岭乡。
 # translit = tàipínglǐxiāngyuánshǔhúnánshěngyizhāngxiànxiàxiáxiāng,2012nián4yuèchèxiāo,yǔshā坪xiāngyīqǐchéngjiànzhìhébìngzhìxīnshèdewǔlǐngxiāng.
 1	太平	太平	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=tàipíng|LTranslit=tàipíng
@@ -7865,6 +8148,7 @@
 30	。	。	PUNCT	.	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s284
+# parallel_id = zhgsd/test284
 # text = 太极剑的历史虽不长，但很受太极爱好者欢迎，其流行程度实超过太极刀、枪、棍、杆等器械。
 # translit = tàijíjiàndelìshǐsuībùzhǎng,dànhěnshòutàijí'àihǎozhěhuanyíng,qíliúxíngchéngdùshíchāoguòtàijídāo,qiāng,gùn,gānděngqìxiè.
 1	太极	太极	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=tàijí|LTranslit=tàijí
@@ -7900,6 +8184,7 @@
 31	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s285
+# parallel_id = zhgsd/test285
 # text = 太极分别于2012年5月4日及2012年8月11日在红磡体育馆举行入行27周年演唱会。
 # translit = tàijífēnbiéyú2012nián5yuè4rìjí2012nián8yuè11rìzàihóng磡tǐyùguǎnjǔxíngrùxíng27zhōuniányǎnchànghuì.
 1	太极	太极	PROPN	NNP	_	21	nsubj	_	SpaceAfter=No|Translit=tàijí|LTranslit=tàijí
@@ -7931,6 +8216,7 @@
 27	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s286
+# parallel_id = zhgsd/test286
 # text = 但是由于丰臣秀吉在日本人心中的影响，人们把平民出身的政要与丰太合相比，称为“今太合”。
 # translit = dànshìyóuyúfēngchénxiùjízàirìběnrénxīnzhōngdeyǐngxiǎng,rénmenbǎpíngmínchūshēndezhèngyàoyǔfēngtàihéxiāngbǐ,chēngwèi“jīntàihé”.
 1	但是	但是	SCONJ	RB	_	23	mark	_	SpaceAfter=No|Translit=dànshì|LTranslit=dànshì
@@ -7964,6 +8250,7 @@
 29	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s287
+# parallel_id = zhgsd/test287
 # text = 丰臣秀吉将关白之职让给了外甥丰臣秀次后，自称太合。
 # translit = fēngchénxiùjíjiāngguānbáizhīzhírànggěilewài甥fēngchénxiùcìhòu,zìchēngtàihé.
 1	丰臣	丰臣	PROPN	NNP	_	14	nsubj	_	SpaceAfter=No|Translit=fēngchén|LTranslit=fēngchén
@@ -7984,6 +8271,7 @@
 16	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s288
+# parallel_id = zhgsd/test288
 # text = 太阳能发电把阳光转换成电能，可直接使用太阳能光伏（PV），或间接使用聚光太阳能热发电（CSP）。
 # translit = tàiyángnéngfādiànbǎyángguāngzhuǎnhuànchéngdiànnéng,kězhíjiēshǐyòngtàiyángnéngguāngfú(PV),huòjiānjiēshǐyòngjùguāngtàiyángnéngrèfādiàn(CSP).
 1	太阳	太阳	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=tàiyáng|LTranslit=tàiyáng
@@ -8019,6 +8307,7 @@
 31	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s289
+# parallel_id = zhgsd/test289
 # text = 而宫内的每个房间门口，又各有几名看门妇把守。
 # translit = 'érgōngnèideměigèfángjiānménkǒu,yòugèyǒujǐmíngkànménfùbǎshǒu.
 1	而	而	SCONJ	RB	_	10	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -8039,6 +8328,7 @@
 16	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s290
+# parallel_id = zhgsd/test290
 # text = 赫伯特的一些日记被送回英国，到了丹尼尔手里。
 # translit = hèbótèdeyīxiērìjìbèisònghuíyīngguó,dàoledānní'ěrshǒulǐ.
 1	赫伯特	赫伯特	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=hèbótè|LTranslit=hèbótè
@@ -8056,6 +8346,7 @@
 13	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s291
+# parallel_id = zhgsd/test291
 # text = 同时，凌统骗曹仁误信周瑜大营仍有大军留守，未予以全力袭击。
 # translit = tóngshí,凌tǒngpiàn曹rénwùxìnzhōu瑜dàyíngréngyǒudàjūnliúshǒu,wèiyǔyǐquánlìxíjī.
 1	同时	同时	NOUN	NN	_	5	nmod:tmod	_	SpaceAfter=No|Translit=tóngshí|LTranslit=tóngshí
@@ -8082,6 +8373,7 @@
 22	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s292
+# parallel_id = zhgsd/test292
 # text = 夸克有着多种不同的内在特性，包括电荷、色荷、自旋及质量等。
 # translit = kuākèyǒuzheduōzhǒngbùtóngdenèizàitèxìng,bāokuòdiànhé,sèhé,zìxuánjízhìliàngděng.
 1	夸克	夸克	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=kuākè|LTranslit=kuākè
@@ -8106,6 +8398,7 @@
 20	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s293
+# parallel_id = zhgsd/test293
 # text = 夸克新星是一种假设的超新星，当中子星发生自发性的塌缩变可能成为夸克星。
 # translit = kuākèxīnxīngshìyīzhǒngjiǎshèdechāoxīnxīng,dāngzhōngzixīngfāshēngzìfāxìngdetāsuōbiànkěnéngchéngwèikuākèxīng.
 1	夸克	夸克	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=kuākè|LTranslit=kuākè
@@ -8135,6 +8428,7 @@
 25	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s294
+# parallel_id = zhgsd/test294
 # text = 12月4日奇尔沙治号离开舰队，在6日抵达横须贺休假。
 # translit = 12yuè4rìqí'ěrshāzhìhàolíkāijiànduì,zài6rìdǐdáhéngxūhèxiūjiǎ.
 1	12	12	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=12|LTranslit=12
@@ -8155,6 +8449,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s295
+# parallel_id = zhgsd/test295
 # text = 1961年3月3日，奇尔沙治号再次前往西太平洋巡航。
 # translit = 1961nián3yuè3rì,qí'ěrshāzhìhàozàicìqiánwǎngxitàipíngyángxúnháng.
 1	1961	1961	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1961|LTranslit=1961
@@ -8175,6 +8470,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s296
+# parallel_id = zhgsd/test296
 # text = 辖区北部属于中国山地，多为山林地，南部为日本原高原。
 # translit = xiáqūběibùshǔyúzhōngguóshānde,duōwèishānlínde,nánbùwèirìběnyuángāoyuán.
 1	辖区	辖区	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=xiáqū|LTranslit=xiáqū
@@ -8197,6 +8493,7 @@
 18	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s297
+# parallel_id = zhgsd/test297
 # text = 随着香港社会的资讯逐渐流通，节目的需求也大为降低，因此于1996年停播。
 # translit = suízhexiānggǎngshèhuìdezīxùnzhújiànliútōng,jiémùdexūqiúyědàwèijiàngdī,yīncǐyú1996niántíngbō.
 1	随	随	VERB	VV	_	15	advcl	_	SpaceAfter=No|Translit=suí|LTranslit=suí
@@ -8225,6 +8522,7 @@
 24	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s298
+# parallel_id = zhgsd/test298
 # text = 奋斗中学，是内蒙古自治区巴彦淖尔市杭锦后旗设立的一个高级中学，位于杭锦后旗陕坝镇，学校成立于1942年，为爱国将领傅作义创建，也是内蒙古第一所中学。
 # translit = fèndòuzhōngxué,shìnèiménggǔzìzhìqūba彦淖'ěrshì杭jǐnhòuqíshèlìdeyīgègāojízhōngxué,wèiyú杭jǐnhòuqí陕bàzhèn,xuéxiàochénglìyú1942nián,wèi'àiguójiānglǐngfuzuòyìchuàngjiàn,yěshìnèiménggǔdìyīsuǒzhōngxué.
 1	奋斗	奋斗	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=fèndòu|LTranslit=fèndòu
@@ -8273,6 +8571,7 @@
 44	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s299
+# parallel_id = zhgsd/test299
 # text = 近代意义上的“契约自由原则”，可以追溯到1804年颁布的《法国民法典》。
 # translit = jìndàiyìyìshàngde“契yuēzìyóuyuánzé”,kěyǐzhuī溯dào1804niánbānbùde«fǎguómínfǎdiǎn».
 1	近代	近代	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=jìndài|LTranslit=jìndài
@@ -8300,6 +8599,7 @@
 23	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s300
+# parallel_id = zhgsd/test300
 # text = 园内拥有19万平方呎天然树林，当中大小树木多达千余棵。
 # translit = yuánnèiyōngyǒu19wànpíngfāng呎tiānránshùlín,dāngzhōngdàxiǎoshùmùduōdáqiānyúkē.
 1	园内	园内	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=yuánnèi|LTranslit=yuánnèi
@@ -8318,6 +8618,7 @@
 14	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s301
+# parallel_id = zhgsd/test301
 # text = 中世纪的印度大哲学家商羯罗选出一些重要的奥义书作注，称它们为“主要奥义书”（Mukhya Upanishad）。
 # translit = zhōngshìjìdeyìndùdàzhéxuéjiāshāng羯luōxuǎnchūyīxiēzhòngyàode'àoyìshūzuòzhù,chēngtāmenwèi“zhǔyào'àoyìshū”(Mukhya Upanishad).
 1	中	中	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=zhōng|LTranslit=zhōng
@@ -8351,6 +8652,7 @@
 29	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s302
+# parallel_id = zhgsd/test302
 # text = 不过，吸引游客的不只是这些主题公园。
 # translit = bùguò,xīyǐnyóukèdebùzhǐshìzhèxiēzhǔtígōngyuán.
 1	不过	不过	SCONJ	RB	_	11	mark	_	SpaceAfter=No|Translit=bùguò|LTranslit=bùguò
@@ -8367,6 +8669,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s303
+# parallel_id = zhgsd/test303
 # text = 城市地标为伊欧拉湖（Lake Eola），而奥兰多市长为巴迪·戴尔（Buddy Dyer）。
 # translit = chéngshìdebiāowèiyī'ōulāhú(Lake Eola),'ér'àolánduōshìzhǎngwèibadí·dài'ěr(Buddy Dyer).
 1	城市	城市	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=chéngshì|LTranslit=chéngshì
@@ -8393,6 +8696,7 @@
 22	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s304
+# parallel_id = zhgsd/test304
 # text = 他的一个儿子Luna后来成了著名水文学家和加州大学伯克利分校的地质学教授。
 # translit = tādeyīgèrziLunahòuláichénglezhemíngshuǐwénxuéjiāhéjiāzhōudàxuébókèlìfēnxiàodedezhìxuéjiàoshòu.
 1	他	他	PRON	PRP	Person=3	5	det	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -8420,6 +8724,7 @@
 23	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s305
+# parallel_id = zhgsd/test305
 # text = 他的自然写作以其朴素直接而闻名。
 # translit = tādezìránxiězuòyǐqípǔsùzhíjiē'érwénmíng.
 1	他	他	PRON	PRP	Person=3	4	det	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -8435,6 +8740,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s306
+# parallel_id = zhgsd/test306
 # text = 离开本国很久的阿凯亚首领们纷纷回国，奥德修斯也带着他的伙伴，乘船向他的故乡伊塔克出发。
 # translit = líkāiběnguóhěnjiǔde'ā凯yàshǒulǐngmenfēnfēnhuíguó,'àodéxiūsīyědàizhetādehuǒbàn,chéngchuánxiàngtādegùxiāngyītǎkèchūfā.
 1	离开	离开	VERB	VV	_	7	acl:relcl	_	SpaceAfter=No|Translit=líkāi|LTranslit=líkāi
@@ -8465,6 +8771,7 @@
 26	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s307
+# parallel_id = zhgsd/test307
 # text = 1945年3月，苏军攻打柯尼斯堡。
 # translit = 1945nián3yuè,sūjūngōngdǎ柯nísībǎo.
 1	1945	1945	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1945|LTranslit=1945
@@ -8479,6 +8786,7 @@
 10	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s308
+# parallel_id = zhgsd/test308
 # text = 绝大多数最佳影片是在美国以外拍摄的，这说明了电影制作国际化水平的提高，也模糊了所谓好莱坞电影的定义。
 # translit = juédàduōshùzuìjiāyǐngpiànshìzàiměiguóyǐwàipāishède,zhèshuōmínglediànyǐngzhìzuòguójìhuàshuǐpíngdetígāo,yěmóhulesuǒwèihǎo莱坞diànyǐngdedìngyì.
 1	绝	绝	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=jué|LTranslit=jué
@@ -8516,6 +8824,7 @@
 33	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s309
+# parallel_id = zhgsd/test309
 # text = 奥斯曼旗帜是指奥斯曼王朝苏丹使用的任何一面旗帜，包括奥斯曼帝国的各种旗帜，以及苏丹在不同场合使用的旗帜。
 # translit = 'àosīmànqízhìshìzhǐ'àosīmànwángcháosūdānshǐyòngderènhéyīmiànqízhì,bāokuò'àosīmàndìguódegèzhǒngqízhì,yǐjísūdānzàibùtóngchǎnghéshǐyòngdeqízhì.
 1	奥斯曼	奥斯曼	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit='àosīmàn|LTranslit='àosīmàn
@@ -8550,6 +8859,7 @@
 30	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s310
+# parallel_id = zhgsd/test310
 # text = 镇上有3630人口（2010年1月1日），一个火车站（由丹麦国有铁路运营）和到欧登塞和斯文堡的公交车（由菲英公交公司运营）。
 # translit = zhènshàngyǒu3630rénkǒu(2010nián1yuè1rì),yīgèhuǒchēzhàn(yóudānmàiguóyǒutiělùyùnyíng)hédào'ōudēngsāihésīwénbǎodegōngjiāochē(yóufēiyīnggōngjiāogōngsīyùnyíng).
 1	镇上	镇上	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=zhènshàng|LTranslit=zhènshàng
@@ -8595,6 +8905,7 @@
 41	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s311
+# parallel_id = zhgsd/test311
 # text = 2000年，挪威国会宪法委员会为此事件，召开一项公听会，以听取机场规划时期所有可疑的不正当事件，并于2001年发表正式报告。
 # translit = 2000nián,挪wēiguóhuìxiànfǎwěiyuánhuìwèicǐshìjiàn,zhàokāiyīxiànggōngtīnghuì,yǐtīngqǔjīchǎngguīhuàshíqīsuǒyǒukěyídebùzhèngdāngshìjiàn,bìngyú2001niánfābiǎozhèngshìbàogào.
 1	2000	2000	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2000|LTranslit=2000
@@ -8637,6 +8948,7 @@
 38	。	。	PUNCT	.	_	35	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s312
+# parallel_id = zhgsd/test312
 # text = 机场所在区域，有一大型地下水地层，机场运作受质疑会污染水源。
 # translit = jīchǎngsuǒzàiqūyù,yǒuyīdàxíngdexiàshuǐdecéng,jīchǎngyùnzuòshòuzhìyíhuìwūrǎnshuǐyuán.
 1	机场	机场	NOUN	NN	_	3	nsubj	_	SpaceAfter=No|Translit=jīchǎng|LTranslit=jīchǎng
@@ -8661,6 +8973,7 @@
 20	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s313
+# parallel_id = zhgsd/test313
 # text = 勒维耶推测是因为存在一颗未知行星的引力作用，使天王星的轨道运动受到干扰，也就是天文学上所谓的“摄动”影响。
 # translit = lēiwéiyétuīcèshìyīnwèicúnzàiyīkēwèizhīxíngxīngdeyǐnlìzuòyòng,shǐtiānwángxīngdeguǐdàoyùndòngshòudàogànrǎo,yějiùshìtiānwénxuéshàngsuǒwèide“shèdòng”yǐngxiǎng.
 1	勒维耶	勒维耶	PROPN	NNP	_	2	nsubj	_	SpaceAfter=No|Translit=lēiwéiyé|LTranslit=lēiwéiyé
@@ -8700,6 +9013,7 @@
 35	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s314
+# parallel_id = zhgsd/test314
 # text = 1980年代中期起奥林匹亚公司的经济状况开始变坏。
 # translit = 1980niándàizhōngqīqǐ'àolínpǐyàgōngsīdejīngjìzhuàngkuàngkāishǐbiànhuài.
 1	1980	1980	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=1980|LTranslit=1980
@@ -8717,6 +9031,7 @@
 13	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s315
+# parallel_id = zhgsd/test315
 # text = 工厂在德国西北部到处购置车床。
 # translit = gōngchǎngzàidéguóxiběibùdàochùgòuzhìchēchuáng.
 1	工厂	工厂	NOUN	NN	_	7	nsubj	_	SpaceAfter=No|Translit=gōngchǎng|LTranslit=gōngchǎng
@@ -8730,6 +9045,7 @@
 9	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s316
+# parallel_id = zhgsd/test316
 # text = 2009年，希腊政府面对负债累累的奥林匹克航空公司，决定实行私有化计划。
 # translit = 2009nián,xī腊zhèngfǔmiànduìfùzhàilèilèide'àolínpǐkèhángkōnggōngsī,juédìngshíxíngsīyǒuhuàjìhuà.
 1	2009	2009	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2009|LTranslit=2009
@@ -8753,6 +9069,7 @@
 19	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s317
+# parallel_id = zhgsd/test317
 # text = 1689年英国在光荣革命后加入同盟，奥格斯堡同盟改称“大同盟”，此时与法国发生激烈的大同盟战争（1688-1697年，又称“九年战争”），虽未能战胜法国陆军，但一定程度上维持住欧洲的势力均衡。
 # translit = 1689niányīngguózàiguāngrónggémìnghòujiārùtóngméng,'àogésībǎotóngménggǎichēng“dàtóngméng”,cǐshíyǔfǎguófāshēngjīlièdedàtóngméngzhànzhēng(1688-1697nián,yòuchēng“jiǔniánzhànzhēng”),suīwèinéngzhànshèngfǎguólùjūn,dànyīdìngchéngdùshàngwéichízhù'ōuzhōudeshìlìjūnhéng.
 1	1689	1689	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1689|LTranslit=1689
@@ -8816,6 +9133,7 @@
 59	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s318
+# parallel_id = zhgsd/test318
 # text = 然而，他最终在2001年转会的球队却是英超的阿斯顿维拉，转会费为500万英镑。
 # translit = rán'ér,tāzuìzhōngzài2001niánzhuǎnhuìdeqiúduìquèshìyīngchāode'āsīdùnwéilā,zhuǎnhuìfèiwèi500wànyīng镑.
 1	然而	然而	SCONJ	RB	_	14	mark	_	SpaceAfter=No|Translit=rán'ér|LTranslit=rán'ér
@@ -8842,6 +9160,7 @@
 22	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s319
+# parallel_id = zhgsd/test319
 # text = 该小镇位于布莱克伍德河流入弗林德斯湾的河口旁。
 # translit = gāixiǎozhènwèiyúbù莱kèwudéhéliúrùfúlíndésīwāndehékǒupáng.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -8859,6 +9178,7 @@
 13	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s320
+# parallel_id = zhgsd/test320
 # text = 古代，奥塞提亚语曾采用希腊字母拼写，现代则使用一套改良过的西里尔字母。
 # translit = gǔdài,'àosāitíyàyǔcéngcǎiyòngxī腊zìmǔpīnxiě,xiàndàizéshǐyòngyītàogǎiliángguòdexilǐ'ěrzìmǔ.
 1	古代	古代	NOUN	NN	_	6	nmod:tmod	_	SpaceAfter=No|Translit=gǔdài|LTranslit=gǔdài
@@ -8884,6 +9204,7 @@
 21	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s321
+# parallel_id = zhgsd/test321
 # text = 希拉蕊的得票率只有37%。
 # translit = xīlā蕊dedepiàolǜzhǐyǒu37%.
 1	希拉蕊	希拉蕊	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=xīlā蕊|LTranslit=xīlā蕊
@@ -8895,6 +9216,7 @@
 7	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s322
+# parallel_id = zhgsd/test322
 # text = 他目前效力于法甲球队波尔多。
 # translit = tāmùqiánxiàolìyúfǎjiǎqiúduìbō'ěrduō.
 1	他	他	PRON	PRP	Person=3	3	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -8907,6 +9229,7 @@
 8	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s323
+# parallel_id = zhgsd/test323
 # text = 尽管博伊西县、内兹佩尔塞县和肖肖尼县与奥怀希县同时成立，但是因它们是由华盛顿领地成立的，因此直至1864年2月都不被爱达荷领地承认。
 # translit = jǐnguǎnbóyīxixiàn,nèi兹pèi'ěrsāixiànhéxiàoxiàoníxiànyǔ'àohuáixīxiàntóngshíchénglì,dànshìyīntāmenshìyóuhuáshèngdùnlǐngdechénglìde,yīncǐzhízhì1864nián2yuèdōubùbèi'àidáhélǐngdechéngrèn.
 1	尽管	尽管	ADP	IN	_	14	case	_	SpaceAfter=No|Translit=jǐnguǎn|LTranslit=jǐnguǎn
@@ -8950,6 +9273,7 @@
 39	。	。	PUNCT	.	_	38	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s324
+# parallel_id = zhgsd/test324
 # text = 平均每户有2.85人，而平均每个家庭则有3.35人。
 # translit = píngjūnměihùyǒu2.85rén,'érpíngjūnměigèjiātíngzéyǒu3.35rén.
 1	平均	平均	ADV	RB	_	3	advmod	_	SpaceAfter=No|Translit=píngjūn|LTranslit=píngjūn
@@ -8969,6 +9293,7 @@
 15	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s325
+# parallel_id = zhgsd/test325
 # text = 他父亲的农用机械厂也在这一时期倒闭，辛德勒为此失业了一年。
 # translit = tāfùqīndenóngyòngjīxièchǎngyězàizhèyīshíqīdàobì,xīndélēiwèicǐshīyèleyīnián.
 1	他	他	PRON	PRP	Person=3	2	nmod	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -8995,6 +9320,7 @@
 22	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s326
+# parallel_id = zhgsd/test326
 # text = 奥斯卡从少年时代就喜欢摩托车，他买下了一辆竞速摩托车并在之后几年里参加山区的赛车比赛。
 # translit = 'àosīkǎcóngshǎoniánshídàijiùxǐhuanmótuōchē,tāmǎixiàleyīliàngjìngsùmótuōchēbìngzàizhīhòujǐniánlǐcānjiāshānqūdesàichēbǐsài.
 1	奥斯卡	奥斯卡	PROPN	NNP	_	6	nsubj	_	SpaceAfter=No|Translit='àosīkǎ|LTranslit='àosīkǎ
@@ -9028,6 +9354,7 @@
 29	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s327
+# parallel_id = zhgsd/test327
 # text = 念完小学和初中后，辛德勒进入一所技校学习，但于1924年因伪造成绩被开除。
 # translit = niànwánxiǎoxuéhéchūzhōnghòu,xīndélēijìnrùyīsuǒjìxiàoxuéxí,dànyú1924niányīnwěizàochéngjībèikāichú.
 1	念	念	VERB	VV	_	23	advcl	_	SpaceAfter=No|Translit=niàn|LTranslit=niàn
@@ -9056,6 +9383,7 @@
 24	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s328
+# parallel_id = zhgsd/test328
 # text = 莫里逊组过去是个多样化的动物群。
 # translit = mòlǐxùnzǔguòqùshìgèduōyànghuàdedòngwùqún.
 1	莫里逊	莫里逊	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=mòlǐxùn|LTranslit=mòlǐxùn
@@ -9071,6 +9399,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s329
+# parallel_id = zhgsd/test329
 # text = 南非之前的国旗（1927-1994）中也有一支直挂的奥兰治自由邦国旗，就在它中间的白色条纹里。
 # translit = nánfēizhīqiándeguóqí(1927-1994)zhōngyěyǒuyīzhīzhíguàde'àolánzhìzìyóubāngguóqí,jiùzàitāzhōngjiāndebáisètiáowénlǐ.
 1	南非	南非	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=nánfēi|LTranslit=nánfēi
@@ -9105,6 +9434,7 @@
 30	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s330
+# parallel_id = zhgsd/test330
 # text = 他出生于雷昂，是弗鲁埃拉（父亲为坎塔布里亚的佩德罗）的儿子；阿斯图里亚斯的阿方索一世的侄子；并且是阿方索继承人残酷的弗鲁埃拉的一个堂弟。
 # translit = tāchūshēngyúléi'áng,shìfúlǔ'āilā(fùqīnwèikǎntǎbùlǐyàdepèidéluō)derzi;'āsītúlǐyàsīde'āfāngsuǒyīshìde侄zi;bìngqiěshì'āfāngsuǒjìchéngréncánkùdefúlǔ'āilādeyīgètángdì.
 1	他	他	PRON	PRP	Person=3	16	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -9146,6 +9476,7 @@
 37	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s331
+# parallel_id = zhgsd/test331
 # text = 史书上唯一有记载的他的事迹是镇压一起农奴的动乱。
 # translit = shǐshūshàngwéiyīyǒujìzàidetādeshìjīshìzhènyāyīqǐnóngnúdedòngluàn.
 1	史书	史书	NOUN	NN	_	4	obl	_	SpaceAfter=No|Translit=shǐshū|LTranslit=shǐshū
@@ -9167,6 +9498,7 @@
 17	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s332
+# parallel_id = zhgsd/test332
 # text = 结党后，该党即展开了“公认候选人公开募集”活动，但直至选举公示之日，该党也没有公认任何一位通过这一方法的候选人。
 # translit = jiédǎnghòu,gāidǎngjízhǎnkāile“gōngrènhouxuǎnréngōngkāi募jí”huódòng,dànzhízhìxuǎnjǔgōngshìzhīrì,gāidǎngyěméiyǒugōngrènrènhéyīwèitōngguòzhèyīfāngfǎdehouxuǎnrén.
 1	结党	结党	VERB	VV	_	6	advcl	_	SpaceAfter=No|Translit=jiédǎng|LTranslit=jiédǎng
@@ -9209,6 +9541,7 @@
 38	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s333
+# parallel_id = zhgsd/test333
 # text = 老街以红桧建成，早年没有街名，当地人仅以“街仔”称之。
 # translit = lǎojiēyǐhóng桧jiànchéng,zǎoniánméiyǒujiēmíng,dāngderénjǐnyǐ“jiēzǐ”chēngzhī.
 1	老街	老街	NOUN	NN	_	7	nsubj	_	SpaceAfter=No|Translit=lǎojiē|LTranslit=lǎojiē
@@ -9232,6 +9565,7 @@
 19	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s334
+# parallel_id = zhgsd/test334
 # text = 每段介绍两个无厘头的新闻后，方芳芳与巴戈就感谢观众收看〈新闻炮〉，新闻摄影棚灯光调暗，巴戈仍然与方芳芳进行一小段对话；跟第一段短剧一样，有时候巴戈又会被方芳芳打一巴掌。
 # translit = měiduànjièshàoliǎnggèwúlítóudexīnwénhòu,fāng芳芳yǔba戈jiùgǎnxièguānzhòngshōukàn<xīnwénpào>,xīnwénshèyǐngpéngdēngguāngdiào'àn,ba戈réngrányǔfāng芳芳jìnxíngyīxiǎoduànduìhuà;gēndìyīduànduǎnjùyīyàng,yǒushíhouba戈yòuhuìbèifāng芳芳dǎyībazhǎng.
 1	每段	每段	DET	DT	_	2	obl	_	SpaceAfter=No|Translit=měiduàn|LTranslit=měiduàn
@@ -9295,6 +9629,7 @@
 59	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s335
+# parallel_id = zhgsd/test335
 # text = 李妍采从小跟母亲相依为命，多年来努力存钱，愿望是找个好男人结婚，然后买房子给母亲。
 # translit = li妍cǎicóngxiǎogēnmǔqīnxiāngyīwèimìng,duōniánláinǔlìcúnqián,yuànwàngshìzhǎogèhǎonánrénjiéhūn,ránhòumǎifángzigěimǔqīn.
 1	李	李	PROPN	NNP	_	13	nsubj	_	SpaceAfter=No|Translit=li|LTranslit=li
@@ -9327,6 +9662,7 @@
 28	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s336
+# parallel_id = zhgsd/test336
 # text = 由于客厅女仆主要负责接客，因此穿着比较注重外表而不重实用性。
 # translit = yóuyúkètīngnǚ仆zhǔyàofùzéjiēkè,yīncǐchuānzhebǐjiàozhùzhòngwàibiǎo'érbùzhòngshíyòngxìng.
 1	由于	由于	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -9350,6 +9686,7 @@
 19	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s337
+# parallel_id = zhgsd/test337
 # text = 除了女管家和贴身女仆的高级女仆外，多数大宅第中女仆都必须穿着制服。
 # translit = chúlenǚguǎnjiāhétiēshēnnǚ仆degāojínǚ仆wài,duōshùdàzháidìzhōngnǚ仆dōubìxūchuānzhezhìfú.
 1	除	除	VERB	VV	_	20	advcl	_	SpaceAfter=No|Translit=chú|LTranslit=chú
@@ -9376,6 +9713,7 @@
 22	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s338
+# parallel_id = zhgsd/test338
 # text = 虽然康守时在战争中途带来了三万人来援助地下军，但对于敌方拥有五十五万大军的情况来说仍是杯水车薪。
 # translit = suīránkāngshǒushízàizhànzhēngzhōngtúdàiláilesānwànrénláiyuánzhùdexiàjūn,dànduìyúdífāngyōngyǒuwǔshíwǔwàndàjūndeqíngkuàngláishuōréngshìbēishuǐchēxīn.
 1	虽然	虽然	ADP	IN	_	7	case	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -9409,6 +9747,7 @@
 29	。	。	PUNCT	.	_	28	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s339
+# parallel_id = zhgsd/test339
 # text = 因为用女性的角度来描写战国时代，不只吸引原本男性视角观点出发的日本战国迷，也广泛受到家庭主妇的支持，创下平均收视率31.8%的纪录。
 # translit = yīnwèiyòngnǚxìngdejiǎodùláimiáoxiězhànguóshídài,bùzhǐxīyǐnyuánběnnánxìngshìjiǎoguāndiǎnchūfāderìběnzhànguómí,yěguǎngfànshòudàojiātíngzhǔfùdezhīchí,chuàngxiàpíngjūnshōushìlǜ31.8%dejìlù.
 1	因为	因为	ADP	IN	_	26	case	_	SpaceAfter=No|Translit=yīnwèi|LTranslit=yīnwèi
@@ -9452,6 +9791,7 @@
 39	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s340
+# parallel_id = zhgsd/test340
 # text = 女真语最初使用女真文，后来这种文字渐渐消亡。
 # translit = nǚzhēnyǔzuìchūshǐyòngnǚzhēnwén,hòuláizhèzhǒngwénzìjiànjiànxiāowáng.
 1	女真	女真	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=nǚzhēn|LTranslit=nǚzhēn
@@ -9470,6 +9810,7 @@
 14	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s341
+# parallel_id = zhgsd/test341
 # text = 由于隆也的寿命差不多已到尽头，所以他希望看到将世界连同他自己的寿命一起结束。
 # translit = yóuyúlóngyědeshòumìngchàbùduōyǐdàojǐntóu,suǒyǐtāxīwàngkàndàojiāngshìjièliántóngtāzìjǐdeshòumìngyīqǐjiéshù.
 1	由于	由于	ADP	IN	_	7	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -9497,6 +9838,7 @@
 23	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s342
+# parallel_id = zhgsd/test342
 # text = 虽然这种分期没有严格的规则，但是解释某些变化时很有用。
 # translit = suīránzhèzhǒngfēnqīméiyǒuyángédeguīzé,dànshìjiěshìmǒuxiēbiànhuàshíhěnyǒuyòng.
 1	虽然	虽然	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -9518,6 +9860,7 @@
 17	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s343
+# parallel_id = zhgsd/test343
 # text = 香会的历史最早可溯至明朝。
 # translit = xiānghuìdelìshǐzuìzǎokě溯zhìmíngcháo.
 1	香会	香会	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=xiānghuì|LTranslit=xiānghuì
@@ -9531,6 +9874,7 @@
 9	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s344
+# parallel_id = zhgsd/test344
 # text = 由于喜欢花的缘故，罗宾还会用花来表达对别人与自己的评断印象，千阳号也特别为她设置了花圃。
 # translit = yóuyúxǐhuanhuādeyuángù,luōbīnháihuìyònghuāláibiǎodáduìbiérényǔzìjǐdepíngduànyìnxiàng,qiānyánghàoyětèbiéwèitāshèzhìlehuā圃.
 1	由于	由于	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -9566,6 +9910,7 @@
 31	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s345
+# parallel_id = zhgsd/test345
 # text = 在1963年，他们找到一个乡村小酒馆并在加泰隆尼亚期间作为他们的家和工作室。
 # translit = zài1963nián,tāmenzhǎodàoyīgèxiāngcūnxiǎojiǔguǎnbìngzàijiātàilóngníyàqījiānzuòwèitāmendejiāhégōngzuòshì.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -9594,6 +9939,7 @@
 24	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s346
+# parallel_id = zhgsd/test346
 # text = 至今为止他在国家队最出名的举动是在温布利球场远射破门3-2击败英格兰，并将后者拒于2008年欧锦赛决赛圈之外。
 # translit = zhìjīnwèizhǐtāzàiguójiāduìzuìchūmíngdejǔdòngshìzàiwēnbùlìqiúchǎngyuǎnshèpòmén3-2jībàiyīnggélán,bìngjiānghòuzhějùyú2008nián'ōujǐnsàijuésàiquānzhīwài.
 1	至	至	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zhì|LTranslit=zhì
@@ -9633,6 +9979,7 @@
 35	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s347
+# parallel_id = zhgsd/test347
 # text = 她亦曾在芬兰、瑞典及法国学习油画，并于1939年开始写作。
 # translit = tāyìcéngzàifēnlán,ruìdiǎnjífǎguóxuéxíyóuhuà,bìngyú1939niánkāishǐxiězuò.
 1	她	她	PRON	PRP	Person=3	17	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -9656,6 +10003,7 @@
 19	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s348
+# parallel_id = zhgsd/test348
 # text = 姆明小说系列英语版本及出版时间如下：
 # translit = mǔmíngxiǎoshuōxìlièyīngyǔbǎnběnjíchūbǎnshíjiānrúxià:
 1	姆明	姆明	PROPN	NNP	_	6	nmod	_	SpaceAfter=No|Translit=mǔmíng|LTranslit=mǔmíng
@@ -9671,6 +10019,7 @@
 11	：	：	PUNCT	:	_	10	punct	_	SpaceAfter=No|Translit=:|LTranslit=:
 
 # sent_id = test-s349
+# parallel_id = zhgsd/test349
 # text = 始创中心前身为始创行、凯声戏院及丽声戏院，当中始创行的圆拱形顶为其建筑特色，后来重建为商场及办公室大厦，并设停车场，于1995年落成，由九龙建业有限公司发展。
 # translit = shǐchuàngzhōngxīnqiánshēnwèishǐchuàngxíng,凯shēngxìyuànjílìshēngxìyuàn,dāngzhōngshǐchuàngxíngdeyuángǒngxíngdǐngwèiqíjiànzhùtèsè,hòuláizhòngjiànwèishāngchǎngjíbàngōngshìdàshà,bìngshètíngchēchǎng,yú1995niánluòchéng,yóujiǔlóngjiànyèyǒuxiàngōngsīfāzhǎn.
 1	始创	始创	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=shǐchuàng|LTranslit=shǐchuàng
@@ -9726,6 +10075,7 @@
 51	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s350
+# parallel_id = zhgsd/test350
 # text = 它能够快速的短跑，当捕捉猎物后，会用指爪及牙齿撕开猎物。
 # translit = tānénggòukuàisùdeduǎnpǎo,dāngbǔzhuōlièwùhòu,huìyòngzhǐzhǎojíyáchǐsīkāilièwù.
 1	它	它	PRON	PRP	Person=3	17	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -9749,6 +10099,7 @@
 19	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s351
+# parallel_id = zhgsd/test351
 # text = 在2006年时，古生物学家根据在阿尔及利亚发现的始新世晚期的化石，命名了一个最新的种：Moeritherium chehbeurameuri。
 # translit = zài2006niánshí,gǔshēngwùxuéjiāgēnjùzài'ā'ěrjílìyàfāxiàndeshǐxīnshìwǎnqīdehuàshí,mìngmíngleyīgèzuìxīndezhǒng:Moeritherium chehbeurameuri.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -9784,6 +10135,7 @@
 31	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s352
+# parallel_id = zhgsd/test352
 # text = 于1984年，查吉特（Sankar Chatterjee）发现了化石，他于1991年指这些化石属于一种比始祖鸟更为古老的鸟类。
 # translit = yú1984nián,chájítè(Sankar Chatterjee)fāxiànlehuàshí,tāyú1991niánzhǐzhèxiēhuàshíshǔyúyīzhǒngbǐshǐzǔniǎogèngwèigǔlǎodeniǎolèi.
 1	于	于	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=yú|LTranslit=yú
@@ -9819,6 +10171,7 @@
 31	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s353
+# parallel_id = zhgsd/test353
 # text = 这一建议在国际动物命名法委员会经过多年辩论后，2011年10月3日伦敦标本被指定为新模式标本。
 # translit = zhèyījiànyìzàiguójìdòngwùmìngmíngfǎwěiyuánhuìjīngguòduōniánbiànlùnhòu,2011nián10yuè3rìlún敦biāoběnbèizhǐdìngwèixīnmóshìbiāoběn.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -9854,6 +10207,7 @@
 31	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s354
+# parallel_id = zhgsd/test354
 # text = 始镜猴科有可以抓住东西的手及脚，手指及脚趾有指甲而没有爪。
 # translit = shǐjìnghóukēyǒukěyǐzhuāzhùdōngxideshǒujíjiǎo,shǒuzhǐjíjiǎo趾yǒuzhǐjiǎ'érméiyǒuzhǎo.
 1	始镜猴	始镜猴	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=shǐjìnghóu|LTranslit=shǐjìnghóu
@@ -9878,6 +10232,7 @@
 20	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s355
+# parallel_id = zhgsd/test355
 # text = 熟料联赛开打前申花与联城合并，姚立君又回到了熟悉的康桥基地，成为当年最富戏剧性的“转会案例”。
 # translit = shúliàoliánsàikāidǎqiánshēnhuāyǔliánchénghébìng,姚lìjūnyòuhuídàoleshúxīdekāngqiáojīde,chéngwèidāngniánzuìfùxìjùxìngde“zhuǎnhuì'ànlì”.
 1	熟	熟	PRON	PRD	_	2	nsubj	_	SpaceAfter=No|Translit=shú|LTranslit=shú
@@ -9915,6 +10270,7 @@
 33	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s356
+# parallel_id = zhgsd/test356
 # text = 1991年，姚夏就入选四川队。
 # translit = 1991nián,姚xiàjiùrùxuǎnsìchuānduì.
 1	1991	1991	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1991|LTranslit=1991
@@ -9929,6 +10285,7 @@
 10	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s357
+# parallel_id = zhgsd/test357
 # text = 2002年姚福信在辽阳市看守所拘留期间，受到了当地公安机关的严重虐待，导致姚福信的腿落下了抽搐的毛病。
 # translit = 2002nián姚fúxìnzàiliáoyángshìkànshǒusuǒjūliúqījiān,shòudàoledāngdegōng'ānjīguāndeyánzhòng虐dài,dǎozhì姚fúxìndetuǐluòxiàlechōu搐demáobìng.
 1	2002	2002	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2002|LTranslit=2002
@@ -9965,6 +10322,7 @@
 32	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s358
+# parallel_id = zhgsd/test358
 # text = 他担任多媒体音乐剧《琥珀》以及儿童狂欢剧《魔山》的音乐总监。
 # translit = tādānrènduōméitǐyīnlèjù«琥珀»yǐjírtóngkuánghuanjù«móshān»deyīnlèzǒngjiān.
 1	他	他	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -9989,6 +10347,7 @@
 20	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s359
+# parallel_id = zhgsd/test359
 # text = 但这次风波并未将其打倒，在年底《Grazia》杂志评选的“十大最佳着装人士”的评选中Kate Moss又一次获得第一名，证明了其的人气与在时尚界的地位。
 # translit = dànzhècìfēngbōbìngwèijiāngqídǎdào,zàiniándǐ«Grazia»zázhìpíngxuǎnde“shídàzuìjiāzhezhuāngrénshì”depíngxuǎnzhōngKate Mossyòuyīcìhuòdedìyīmíng,zhèngmíngleqíderénqìyǔzàishíshàngjièdedewèi.
 1	但	但	SCONJ	RB	_	9	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -10042,6 +10401,7 @@
 49	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s360
+# parallel_id = zhgsd/test360
 # text = 例如，猎户座大星云有单纯的发射谱线，是典型的气体特征；仙女座星系的谱线特征如同恒星。
 # translit = lìrú,lièhùzuòdàxīngyúnyǒudānchúndefāshè谱xiàn,shìdiǎnxíngdeqìtǐtèzhēng;xiannǚzuòxīngxìde谱xiàntèzhēngrútónghéngxīng.
 1	例如	例如	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=lìrú|LTranslit=lìrú
@@ -10073,6 +10433,7 @@
 27	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s361
+# parallel_id = zhgsd/test361
 # text = 1882年8月13日，杰文斯在黑斯廷斯城附近洗海水澡时溺水身亡。
 # translit = 1882nián8yuè13rì,jiéwénsīzàihēisītíngsīchéngfùjìnxǐhǎishuǐzǎoshí溺shuǐshēnwáng.
 1	1882	1882	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1882|LTranslit=1882
@@ -10096,6 +10457,7 @@
 19	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s362
+# parallel_id = zhgsd/test362
 # text = 威廉·普拉格，是在德国出生的美国应用数学家。
 # translit = wēilián·pǔlāgé,shìzàidéguóchūshēngdeměiguóyīngyòngshùxuéjiā.
 1	威廉	威廉	PROPN	NNP	_	13	nsubj	_	SpaceAfter=No|Translit=wēilián|LTranslit=wēilián
@@ -10114,6 +10476,7 @@
 14	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s363
+# parallel_id = zhgsd/test363
 # text = 柏洛兹于青春期早期着手开始写文章与报导。
 # translit = bǎiluò兹yúqīngchūnqīzǎoqīzheshǒukāishǐxiěwénzhāngyǔbàodǎo.
 1	柏洛兹	柏洛兹	PROPN	NNP	_	6	nsubj	_	SpaceAfter=No|Translit=bǎiluò兹|LTranslit=bǎiluò兹
@@ -10130,6 +10493,7 @@
 12	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s364
+# parallel_id = zhgsd/test364
 # text = 身为颓废的一代的主要成员，他是影响流行文化以及文学的前卫作家。
 # translit = shēnwèi颓fèideyīdàidezhǔyàochéngyuán,tāshìyǐngxiǎngliúxíngwénhuàyǐjíwénxuédeqiánwèizuòjiā.
 1	身为	为	VERB	VV	_	19	acl	_	SpaceAfter=No|Translit=shēnwèi|LTranslit=wèi
@@ -10154,6 +10518,7 @@
 20	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s365
+# parallel_id = zhgsd/test365
 # text = 他宣布自己为共和国总统，同伴瓦特金斯为副总统。
 # translit = tāxuānbùzìjǐwèigònghéguózǒngtǒng,tóngbànwǎtèjīnsīwèifùzǒngtǒng.
 1	他	他	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -10172,6 +10537,7 @@
 14	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s366
+# parallel_id = zhgsd/test366
 # text = 回到加利福尼亚州后，他由于支持了一场违反中立法的战争而遭到法庭审判。
 # translit = huídàojiālìfúníyàzhōuhòu,tāyóuyúzhīchíleyīchǎngwéifǎnzhōnglìfǎdezhànzhēng'érzāodàofǎtíngshěnpàn.
 1	回到	回到	VERB	VV	_	18	advcl	_	SpaceAfter=No|Translit=huídào|LTranslit=huídào
@@ -10197,6 +10563,7 @@
 21	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s367
+# parallel_id = zhgsd/test367
 # text = 在他留学期间，欧洲发生了1848年革命。
 # translit = zàitāliúxuéqījiān,'ōuzhōufāshēngle1848niángémìng.
 1	在	在	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -10213,6 +10580,7 @@
 12	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s368
+# parallel_id = zhgsd/test368
 # text = 在民主党领袖卡斯特伦的同意下，沃克袭击了位于里瓦斯的保守党势力。
 # translit = zàimínzhǔdǎnglǐngxiùkǎsītèlúndetóngyìxià,wòkèxíjīlewèiyúlǐwǎsīdebǎoshǒudǎngshìlì.
 1	在	在	ADP	IN	_	7	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -10237,6 +10605,7 @@
 20	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s369
+# parallel_id = zhgsd/test369
 # text = 阿姆斯特朗结婚时买下了位于新堡西杰斯蒙丹尼的杰斯蒙丹尼楼，并开始装修这个庄园。
 # translit = 'āmǔsītèlǎngjiéhūnshímǎixiàlewèiyúxīnbǎoxijiésīméngdānnídejiésīméngdānnílóu,bìngkāishǐzhuāngxiūzhègèzhuāngyuán.
 1	阿姆斯特朗	阿姆斯特朗	PROPN	NNP	_	15	nsubj	_	SpaceAfter=No|Translit='āmǔsītèlǎng|LTranslit='āmǔsītèlǎng
@@ -10261,6 +10630,7 @@
 20	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s370
+# parallel_id = zhgsd/test370
 # text = 两国在1897年开始就这一问题进行谈判，但没有取得任何共识，因为西班牙不愿赋予古巴独立，而古巴也不愿作出任何让步。
 # translit = liǎngguózài1897niánkāishǐjiùzhèyīwèntíjìnxíngtánpàn,dànméiyǒuqǔderènhégòngshi,yīnwèixibānyábùyuàn赋yǔgǔbadúlì,'érgǔbayěbùyuànzuòchūrènhéràngbù.
 1	两	两	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=liǎng|LTranslit=liǎng
@@ -10299,6 +10669,7 @@
 34	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s371
+# parallel_id = zhgsd/test371
 # text = 科特柳的任期几乎和麦金莱的任期一样长，他在这段时间内，逐渐变成了麦金莱的重要助手，相当于出版秘书（Press secretary）和今日的幕僚长。
 # translit = kētèliǔderènqījǐhuhémàijīn莱derènqīyīyàngzhǎng,tāzàizhèduànshíjiānnèi,zhújiànbiànchénglemàijīn莱dezhòngyàozhùshǒu,xiāngdāngyúchūbǎnmìshū(Press secretary)héjīnrìdemùliáozhǎng.
 1	科特柳	科特柳	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=kētèliǔ|LTranslit=kētèliǔ
@@ -10343,6 +10714,7 @@
 40	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s372
+# parallel_id = zhgsd/test372
 # text = 基于大量工人阶级行动的压力，法例于1890年10月1日被废除。
 # translit = jīyúdàliànggōngrénjiējíxíngdòngdeyālì,fǎlìyú1890nián10yuè1rìbèifèichú.
 1	基	基	VERB	VV	_	19	advcl	_	SpaceAfter=No|Translit=jī|LTranslit=jī
@@ -10367,6 +10739,7 @@
 20	。	。	PUNCT	.	_	19	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s373
+# parallel_id = zhgsd/test373
 # text = 虽然俾斯麦说他和威廉的工作关系是一个臣子对他的长官尽忠，实际上俾斯麦拿着管理内政和外交的实权。
 # translit = suīrán俾sīmàishuōtāhéwēiliándegōngzuòguānxìshìyīgèchénziduìtādezhǎngguānjǐnzhōng,shíjìshàng俾sīmàinázheguǎnlǐnèizhènghéwàijiāodeshíquán.
 1	虽然	虽然	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=suīrán|LTranslit=suīrán
@@ -10402,6 +10775,7 @@
 31	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s374
+# parallel_id = zhgsd/test374
 # text = 2013年4月，威廉玛丽校友玛丽·乔·怀特（Mary Jo White）经美国参议院一致同意，担任美国证监会主席。
 # translit = 2013nián4yuè,wēiliánmǎlìxiàoyoumǎlì·乔·huáitè(Mary Jo White)jīngměiguócānyìyuànyīzhìtóngyì,dānrènměiguózhèngjiānhuìzhǔxí.
 1	2013	2013	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=2013|LTranslit=2013
@@ -10436,6 +10810,7 @@
 30	。	。	PUNCT	.	_	25	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s375
+# parallel_id = zhgsd/test375
 # text = 不少从威廉玛丽学院毕业的学生，成为早期美国历史中的重要政治任务的参与者，包括5位美国总统和12位独立宣言签署者（总共56位签字人，威廉玛丽学院的毕业生占了将近四分之一，这些人创建了美国）和许许多多的美国国务卿（举例来说，美国最初的10位国务卿，竟有6位毕业于威廉玛丽学院，其余的均毕业于哈佛大学和普林斯顿大学）。
 # translit = bùshǎocóngwēiliánmǎlìxuéyuànbìyèdexuéshēng,chéngwèizǎoqīměiguólìshǐzhōngdezhòngyàozhèngzhìrènwudecānyǔzhě,bāokuò5wèiměiguózǒngtǒnghé12wèidúlìxuānyánqiānshǔzhě(zǒnggòng56wèiqiānzìrén,wēiliánmǎlìxuéyuàndebìyèshēngzhànlejiāngjìnsìfēnzhīyī,zhèxiērénchuàngjiànleměiguó)héxǔxǔduōduōdeměiguóguówu卿(jǔlìláishuō,měiguózuìchūde10wèiguówu卿,jìngyǒu6wèibìyèyúwēiliánmǎlìxuéyuàn,qíyúdejūnbìyèyúhāfúdàxuéhépǔlínsīdùndàxué).
 1	不少	不少	ADJ	JJ	_	7	amod	_	SpaceAfter=No|Translit=bùshǎo|LTranslit=bùshǎo
@@ -10537,6 +10912,7 @@
 97	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s376
+# parallel_id = zhgsd/test376
 # text = 威廉玛丽学院是全美第二历史悠久的高等学府。
 # translit = wēiliánmǎlìxuéyuànshìquánměidì'èrlìshǐyōujiǔdegāoděngxuéfǔ.
 1	威廉玛丽	威廉玛丽	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=wēiliánmǎlì|LTranslit=wēiliánmǎlì
@@ -10553,6 +10929,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s377
+# parallel_id = zhgsd/test377
 # text = 学院于1776年与英国脱离关系，1906年成为公立大学，1918年男女合校，直到1967年才成为现代综合性大学。
 # translit = xuéyuànyú1776niányǔyīngguótuōlíguānxì,1906niánchéngwèigōnglìdàxué,1918niánnánnǚhéxiào,zhídào1967niáncáichéngwèixiàndàizōnghéxìngdàxué.
 1	学院	学院	NOUN	NN	_	27	nsubj	_	SpaceAfter=No|Translit=xuéyuàn|LTranslit=xuéyuàn
@@ -10590,6 +10967,7 @@
 33	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s378
+# parallel_id = zhgsd/test378
 # text = 为了纪念威廉三世和玛丽二世，学院被命名为威廉与玛丽学院，更因皇家宪章而必须“永远地”保留这校名。
 # translit = wèilejìniànwēiliánsānshìhémǎlì'èrshì,xuéyuànbèimìngmíngwèiwēiliányǔmǎlìxuéyuàn,gèngyīnhuángjiāxiànzhāng'érbìxū“yǒngyuǎnde”bǎoliúzhèxiàomíng.
 1	为了	为了	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=wèile|LTranslit=wèile
@@ -10625,6 +11003,7 @@
 31	。	。	PUNCT	.	_	28	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s379
+# parallel_id = zhgsd/test379
 # text = 威斯康辛号在1941年按照11%扩充法案，于费城造船厂开始建造，在1943年下水，于1944年服役。
 # translit = wēisīkāngxīnhàozài1941nián'ànzhào11%kuòchōngfǎ'àn,yúfèichéngzàochuánchǎngkāishǐjiànzào,zài1943niánxiàshuǐ,yú1944niánfúyì.
 1	威斯康辛	威斯康辛	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=wēisīkāngxīn|LTranslit=wēisīkāngxīn
@@ -10656,6 +11035,7 @@
 27	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s380
+# parallel_id = zhgsd/test380
 # text = 在盾的四周是威斯特法伦的王冠和代表法国的大鹰。
 # translit = zàidùndesìzhōushìwēisītèfǎlúndewángguānhédàibiǎofǎguódedàyīng.
 1	在	在	VERB	VV	_	8	csubj	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -10675,6 +11055,7 @@
 15	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s381
+# parallel_id = zhgsd/test381
 # text = 较近期的说法是极权主义或君主专制更偏重于对于领袖的个人崇拜，前者是真正的独裁政体，后者则是君权神授或政教合一的制度，常以世袭的方式固定下来。
 # translit = jiàojìnqīdeshuōfǎshìjíquánzhǔyìhuòjūnzhǔzhuānzhìgèngpiānzhòngyúduìyúlǐngxiùdegèrénchóngbài,qiánzhěshìzhēnzhèngdedúcáizhèngtǐ,hòuzhězéshìjūnquánshénshòuhuòzhèngjiàohéyīdezhìdù,chángyǐshìxídefāngshìgùdìngxiàlái.
 1	较	较	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=jiào|LTranslit=jiào
@@ -10725,6 +11106,7 @@
 46	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s382
+# parallel_id = zhgsd/test382
 # text = 21世纪初，这些住房均为一位老阿妈家所有，其余人家均为租住户，租住户大都在八廓附近有自己的生意。
 # translit = 21shìjìchū,zhèxiēzhùfángjūnwèiyīwèilǎo'āmājiāsuǒyǒu,qíyúrénjiājūnwèizūzhùhù,zūzhùhùdàdōuzàibākuòfùjìnyǒuzìjǐdeshēngyì.
 1	21	21	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=21|LTranslit=21
@@ -10764,6 +11146,7 @@
 35	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s383
+# parallel_id = zhgsd/test383
 # text = 《婚前特急》，2011年4月1日上映的日本电影。
 # translit = «hūnqiántèjí»,2011nián4yuè1rìshàngyìngderìběndiànyǐng.
 1	《	《	PUNCT	(	_	3	punct	_	SpaceAfter=No|Translit=«|LTranslit=«
@@ -10784,6 +11167,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s384
+# parallel_id = zhgsd/test384
 # text = 人类婚姻史的第二时期，妇女劳动范围逐渐变小，财富及继承问题日趋突出，于是关于个人至亲骨肉的后代观念便成了婚姻的主导动机。
 # translit = rénlèihūnyīnshǐdedì'èrshíqī,fùnǚláodòngfànwéizhújiànbiànxiǎo,cáifùjíjìchéngwèntírìqūtūchū,yúshìguānyúgèrénzhìqīngǔròudehòudàiguānniànbiànchénglehūnyīndezhǔdǎodòngjī.
 1	人类	人类	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=rénlèi|LTranslit=rénlèi
@@ -10824,6 +11208,7 @@
 36	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s385
+# parallel_id = zhgsd/test385
 # text = 通常，婚姻是组成家庭的基础和根据，是家庭成立的标志。
 # translit = tōngcháng,hūnyīnshìzǔchéngjiātíngdejīchǔhégēnjù,shìjiātíngchénglìdebiāozhì.
 1	通常	通常	ADV	RB	_	16	advmod	_	SpaceAfter=No|Translit=tōngcháng|LTranslit=tōngcháng
@@ -10845,6 +11230,7 @@
 17	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s386
+# parallel_id = zhgsd/test386
 # text = 青岛天后宫始建于明代成化三年，初称“天妃宫”，是青岛市区现存最古老的明清砖木结构建筑群。
 # translit = qīngdǎotiānhòugōngshǐjiànyúmíngdàichénghuàsānnián,chūchēng“tiān妃gōng”,shìqīngdǎoshìqūxiàncúnzuìgǔlǎodemíngqīngzhuānmùjiégòujiànzhùqún.
 1	青岛	青岛	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=qīngdǎo|LTranslit=qīngdǎo
@@ -10879,6 +11265,7 @@
 30	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s387
+# parallel_id = zhgsd/test387
 # text = 唐国的末期国君叫做唐叔虞。
 # translit = tángguódemòqīguójūnjiàozuòtángshū虞.
 1	唐国	唐国	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=tángguó|LTranslit=tángguó
@@ -10891,6 +11278,7 @@
 8	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s388
+# parallel_id = zhgsd/test388
 # text = 河南中部某些方言中的子变韵已经成为残余现象。
 # translit = hénánzhōngbùmǒuxiēfāngyánzhōngdezibiàn韵yǐjīngchéngwèicányúxiànxiàng.
 1	河南	河南	PROPN	NNP	_	4	nmod	_	SpaceAfter=No|Translit=hénán|LTranslit=hénán
@@ -10909,6 +11297,7 @@
 14	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s389
+# parallel_id = zhgsd/test389
 # text = 孔恩瀑布由两部分组成，西边的是“桑法尼瀑布”，地势较高，枯水时断流，东边的名为“发芬瀑布”（Phapheng Falls），是孔恩主瀑，孔恩瀑布总宽9.7公里，落差15~24米，年均流量1.2万立方米/秒，号称世界上最宽的瀑布。
 # translit = kǒng'ēnpùbùyóuliǎngbùfēnzǔchéng,xibiāndeshì“sāngfǎnípùbù”,deshìjiàogāo,kūshuǐshíduànliú,dōngbiāndemíngwèi“fāfēnpùbù”(Phapheng Falls),shìkǒng'ēnzhǔpù,kǒng'ēnpùbùzǒngkuān9.7gōnglǐ,luòchà15~24mǐ,niánjūnliúliàng1.2wànlìfāngmǐ/miǎo,hàochēngshìjièshàngzuìkuāndepùbù.
 1	孔恩	孔恩	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=kǒng'ēn|LTranslit=kǒng'ēn
@@ -10978,6 +11367,7 @@
 65	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s390
+# parallel_id = zhgsd/test390
 # text = 孔雀石和蓝铜矿，来自美国亚利桑那州。
 # translit = kǒngquèshíhélántóngkuàng,láizìměiguóyàlìsāngnàzhōu.
 1	孔雀石	孔雀石	NOUN	NN	_	5	nsubj	_	SpaceAfter=No|Translit=kǒngquèshí|LTranslit=kǒngquèshí
@@ -10992,6 +11382,7 @@
 10	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s391
+# parallel_id = zhgsd/test391
 # text = 它们在欧洲是较为普遍的蝴蝶。
 # translit = tāmenzài'ōuzhōushìjiàowèipǔbiàndehúdié.
 1	它们	它	PRON	PRP	Number=Plur|Person=3	8	nsubj	_	SpaceAfter=No|Translit=tāmen|LTranslit=tā
@@ -11005,6 +11396,7 @@
 9	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s392
+# parallel_id = zhgsd/test392
 # text = 翅膀底色是锈红色，翅端上有黑色、蓝色及黄色的眼状斑点。
 # translit = chìbǎngdǐsèshìxiùhóngsè,chìduānshàngyǒuhēisè,lánsèjíhuángsèdeyǎnzhuàng斑diǎn.
 1	翅膀	翅膀	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=chìbǎng|LTranslit=chìbǎng
@@ -11027,6 +11419,7 @@
 18	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s393
+# parallel_id = zhgsd/test393
 # text = 1929年，十三世达赖喇嘛和九世班禅额尔德尼发生斗争。
 # translit = 1929nián,shísānshìdálàilǎmahéjiǔshìbān禅'é'ěrdénífāshēngdòuzhēng.
 1	1929	1929	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1929|LTranslit=1929
@@ -11046,6 +11439,7 @@
 15	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s394
+# parallel_id = zhgsd/test394
 # text = 为便利使用，形码输入法大多设有容错码、万用码以增加输入法对于异体字的处理能力，有些还设有简码以加快输入速度。
 # translit = wèibiànlìshǐyòng,xíngmǎshūrùfǎdàduōshèyǒuróngcuòmǎ,wànyòngmǎyǐzēngjiāshūrùfǎduìyúyìtǐzìdechùlǐnénglì,yǒuxiēháishèyǒujiǎnmǎyǐjiākuàishūrùsùdù.
 1	为	为	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=wèi|LTranslit=wèi
@@ -11084,6 +11478,7 @@
 34	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s395
+# parallel_id = zhgsd/test395
 # text = 孙中山故居纪念馆坐落于中国广东省中山市翠亨村。
 # translit = sūnzhōngshāngùjūjìniànguǎnzuòluòyúzhōngguóguǎngdōngshěngzhōngshānshì翠亨cūn.
 1	孙	孙	PROPN	NNP	_	5	nmod	_	SpaceAfter=No|Translit=sūn|LTranslit=sūn
@@ -11103,6 +11498,7 @@
 15	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s396
+# parallel_id = zhgsd/test396
 # text = 1925年1月至5月，孙云鹏担任正太铁路总工会会长（委员长）。
 # translit = 1925nián1yuèzhì5yuè,sūnyún鹏dānrènzhèngtàitiělùzǒnggōnghuìhuìzhǎng(wěiyuánzhǎng).
 1	1925	1925	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1925|LTranslit=1925
@@ -11128,6 +11524,7 @@
 21	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s397
+# parallel_id = zhgsd/test397
 # text = 孙啸南旧居建筑面积为420平方米，是一座三层砖木结构英庭院式楼房。
 # translit = sūnxiàonánjiùjūjiànzhùmiànjīwèi420píngfāngmǐ,shìyīzuòsāncéngzhuānmùjiégòuyīngtíngyuànshìlóufáng.
 1	孙	孙	PROPN	NNP	_	5	nmod	_	SpaceAfter=No|Translit=sūn|LTranslit=sūn
@@ -11153,6 +11550,7 @@
 21	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s398
+# parallel_id = zhgsd/test398
 # text = 教育部在教育系统开展了“向孟二冬学习”的活动。
 # translit = jiàoyùbùzàijiàoyùxìtǒngkāizhǎnle“xiàng孟'èrdōngxuéxí”dehuódòng.
 1	教育	教育	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=jiàoyù|LTranslit=jiàoyù
@@ -11173,6 +11571,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s399
+# parallel_id = zhgsd/test399
 # text = 2013年第十二届全国运动会上，巴特尔已签约辽宁出战。
 # translit = 2013niándìshí'èrjièquánguóyùndònghuìshàng,batè'ěryǐqiānyuēliáoníngchūzhàn.
 1	2013	2013	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2013|LTranslit=2013
@@ -11192,6 +11591,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s400
+# parallel_id = zhgsd/test400
 # text = 巴特尔作为第二位加盟NBA之中国篮球运动员，于2001年与丹佛掘金队签约，成为第一个在NBA首发的中国球员。
 # translit = batè'ěrzuòwèidì'èrwèijiāméngNBAzhīzhōngguólánqiúyùndòngyuán,yú2001niányǔdānfújuéjīnduìqiānyuē,chéngwèidìyīgèzàiNBAshǒufādezhōngguóqiúyuán.
 1	巴特尔	巴特尔	PROPN	NNP	_	23	nsubj	_	SpaceAfter=No|Translit=batè'ěr|LTranslit=batè'ěr
@@ -11229,6 +11629,7 @@
 33	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s401
+# parallel_id = zhgsd/test401
 # text = 孟加拉狐是较为细小的狐狸，吻较长，耳朵尖长，尾巴约是体长的50-60%。
 # translit = 孟jiālāhúshìjiàowèixìxiǎodehúli,wěnjiàozhǎng,'ěrduojiānzhǎng,wěibayuēshìtǐzhǎngde50-60%.
 1	孟加拉狐	孟加拉狐	NOUN	NN	_	6	nsubj	_	SpaceAfter=No|Translit=孟jiālāhú|LTranslit=孟jiālāhú
@@ -11255,6 +11656,7 @@
 22	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s402
+# parallel_id = zhgsd/test402
 # text = 884年秋，在李克用要求下，僖宗任李克修为昭义节度使，使得昭义镇出现了两位节度使。
 # translit = 884niánqiū,zàilikèyòngyàoqiúxià,僖zōngrènlikèxiūwèi昭yìjiédùshǐ,shǐde昭yìzhènchūxiànleliǎngwèijiédùshǐ.
 1	884	884	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=884|LTranslit=884
@@ -11288,6 +11690,7 @@
 29	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s403
+# parallel_id = zhgsd/test403
 # text = 孟道，五代十国邢州龙冈人，为邢州郡校。
 # translit = 孟dào,wǔdàishíguó邢zhōulónggāngrén,wèi邢zhōu郡xiào.
 1	孟	孟	PROPN	NNP	_	14	nsubj	_	SpaceAfter=No|Translit=孟|LTranslit=孟
@@ -11307,6 +11710,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s404
+# parallel_id = zhgsd/test404
 # text = 3月底，法军攻占澎湖；6月11日，孤拔因病死于澎湖马公。
 # translit = 3yuèdǐ,fǎjūngōngzhànpēnghú;6yuè11rì,gūbáyīnbìngsǐyúpēnghúmǎgōng.
 1	3	3	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=3|LTranslit=3
@@ -11333,6 +11737,7 @@
 22	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s405
+# parallel_id = zhgsd/test405
 # text = 孤子波是一类由于非线性作用引起的横波，它在运动过程中形状保持不变。
 # translit = gūzibōshìyīlèiyóuyúfēixiànxìngzuòyòngyǐnqǐdehéngbō,tāzàiyùndòngguòchéngzhōngxíngzhuàngbǎochíbùbiàn.
 1	孤子	孤子	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=gūzi|LTranslit=gūzi
@@ -11359,6 +11764,7 @@
 22	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s406
+# parallel_id = zhgsd/test406
 # text = 孤海浮灯（The Likes of Us）是名作曲家安德鲁·洛伊·韦伯的音乐剧，原书由莱斯利·汤玛斯基于慈善家汤玛斯·约翰成立贫困儿童院的真实故事创作。
 # translit = gūhǎifúdēng(The Likes of Us)shìmíngzuòqūjiā'āndélǔ·luòyī·韦bódeyīnlèjù,yuánshūyóu莱sīlì·tāngmǎsījīyúcíshànjiātāngmǎsī·yuē翰chénglìpínkùnrtóngyuàndezhēnshígùshìchuàngzuò.
 1	孤海	孤海	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=gūhǎi|LTranslit=gūhǎi
@@ -11404,6 +11810,7 @@
 41	。	。	PUNCT	.	_	20	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s407
+# parallel_id = zhgsd/test407
 # text = 有观点认为，朝鲜语和日语也是孤立语言，它们跟目前世界上已知的语系可能都没有关联。
 # translit = yǒuguāndiǎnrènwèi,cháoxiānyǔhérìyǔyěshìgūlìyǔyán,tāmengēnmùqiánshìjièshàngyǐzhīdeyǔxìkěnéngdōuméiyǒuguānlián.
 1	有	有	VERB	VV	_	0	root	_	SpaceAfter=No|Translit=yǒu|LTranslit=yǒu
@@ -11434,6 +11841,7 @@
 26	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s408
+# parallel_id = zhgsd/test408
 # text = 知名的孤立语言如苏美尔语、巴斯克语、阿伊努语等。
 # translit = zhīmíngdegūlìyǔyánrúsūměi'ěryǔ,basīkèyǔ,'āyīnǔyǔděng.
 1	知名	知名	ADJ	JJ	_	4	amod	_	SpaceAfter=No|Translit=zhīmíng|LTranslit=zhīmíng
@@ -11453,6 +11861,7 @@
 15	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s409
+# parallel_id = zhgsd/test409
 # text = 后来，孙楚先后升任第六旅旅长及第二军第六师师长，任内曾经到日本参观秋操。
 # translit = hòulái,sūnchuxiānhòushēngrèndìliùlǚlǚzhǎngjídì'èrjūndìliùshīshīzhǎng,rènnèicéngjīngdàorìběncānguānqiūcāo.
 1	后来	后来	NOUN	NN	_	6	obl	_	SpaceAfter=No|Translit=hòulái|LTranslit=hòulái
@@ -11480,6 +11889,7 @@
 23	。	。	PUNCT	.	_	21	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s410
+# parallel_id = zhgsd/test410
 # text = 全国警察前五名的射击能手，为人十分豪爽，恐怖事件开始之后，在机场担任着警备工作，负责维持机场的运作畅通。
 # translit = quánguójǐngcháqiánwǔmíngdeshèjīnéngshǒu,wèirénshífēnháoshuǎng,kǒngbùshìjiànkāishǐzhīhòu,zàijīchǎngdānrènzhejǐngbèigōngzuò,fùzéwéichíjīchǎngdeyùnzuòchàngtōng.
 1	全国	全国	NOUN	NN	_	8	nmod	_	SpaceAfter=No|Translit=quánguó|LTranslit=quánguó
@@ -11516,6 +11926,7 @@
 32	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s411
+# parallel_id = zhgsd/test411
 # text = 角色名字参考日本知名漫画家永井豪。
 # translit = jiǎosèmíngzìcānkǎorìběnzhīmíngmànhuàjiāyǒngjǐngháo.
 1	角色	角色	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=jiǎosè|LTranslit=jiǎosè
@@ -11530,6 +11941,7 @@
 10	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s412
+# parallel_id = zhgsd/test412
 # text = 1860年签订的中俄北京条约中规定清政府须将此地大部份割予沙俄，今归俄罗斯滨海边疆区所管。
 # translit = 1860niánqiāndìngdezhōng'éběijīngtiáoyuēzhōngguīdìngqīngzhèngfǔxūjiāngcǐdedàbùfèngēyǔshā'é,jīnguī'éluōsībīnhǎibiānjiāngqūsuǒguǎn.
 1	1860	1860	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1860|LTranslit=1860
@@ -11563,6 +11975,7 @@
 29	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s413
+# parallel_id = zhgsd/test413
 # text = 宁武县在中国山西省西北部、汾河和桑干河上游，是忻州市所辖的一个县。
 # translit = níngwǔxiànzàizhōngguóshānxishěngxiběibù,汾héhésānggànhéshàngyóu,shì忻zhōushìsuǒxiádeyīgèxiàn.
 1	宁武	宁武	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=níngwǔ|LTranslit=níngwǔ
@@ -11592,6 +12005,7 @@
 25	。	。	PUNCT	:	_	24	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s414
+# parallel_id = zhgsd/test414
 # text = 1840年以后，由于战乱频发，宁波人口增长缓慢，特别是抗日战争时期，宁波人口减少了近20%。
 # translit = 1840niányǐhòu,yóuyúzhànluànpínfā,níngbōrénkǒuzēngzhǎnghuǎnmàn,tèbiéshìkàngrìzhànzhēngshíqī,níngbōrénkǒujiǎnshǎolejìn20%.
 1	1840	1840	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1840|LTranslit=1840
@@ -11623,6 +12037,7 @@
 27	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s415
+# parallel_id = zhgsd/test415
 # text = 外来人口在为宁波带来劳动力和经济发展的同时，也带来了社会治安状况的下降和社会资源紧缺。
 # translit = wàiláirénkǒuzàiwèiníngbōdàiláiláodònglìhéjīngjìfāzhǎndetóngshí,yědàiláileshèhuìzhì'ānzhuàngkuàngdexiàjiànghéshèhuìzīyuánjǐnquē.
 1	外来	外来	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=wàilái|LTranslit=wàilái
@@ -11654,6 +12069,7 @@
 27	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s416
+# parallel_id = zhgsd/test416
 # text = 宁波最早的广播电台开办于1932年，为爱好者开办的业余广播电台。
 # translit = níngbōzuìzǎodeguǎngbōdiàntáikāibànyú1932nián,wèi'àihǎozhěkāibàndeyèyúguǎngbōdiàntái.
 1	宁波	宁波	PROPN	NNP	_	5	nmod	_	SpaceAfter=No|Translit=níngbō|LTranslit=níngbō
@@ -11677,6 +12093,7 @@
 19	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s417
+# parallel_id = zhgsd/test417
 # text = 至少从宋代开始，明州即供奉纪信为城隍。
 # translit = zhìshǎocóng宋dàikāishǐ,míngzhōujígōngfèngjìxìnwèichéng隍.
 1	至少	至少	ADV	RB	_	3	advmod	_	SpaceAfter=No|Translit=zhìshǎo|LTranslit=zhìshǎo
@@ -11693,6 +12110,7 @@
 12	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s418
+# parallel_id = zhgsd/test418
 # text = 2004年起，原效实中学高中所辖“国际部”取消，其编制划入宁波外国语学校编制内，称为“宁波外国语学校高中部”。
 # translit = 2004niánqǐ,yuánxiàoshízhōngxuégāozhōngsuǒxiá“guójìbù”qǔxiāo,qíbiānzhìhuàrùníngbōwàiguóyǔxuéxiàobiānzhìnèi,chēngwèi“níngbōwàiguóyǔxuéxiàogāozhōngbù”.
 1	2004	2004	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=2004|LTranslit=2004
@@ -11734,6 +12152,7 @@
 37	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s419
+# parallel_id = zhgsd/test419
 # text = 宁波效实中学是一所位于中国浙江省宁波市的高级中学，有100余年历史，原为私立中学。
 # translit = níngbōxiàoshízhōngxuéshìyīsuǒwèiyúzhōngguó浙jiāngshěngníngbōshìdegāojízhōngxué,yǒu100yúniánlìshǐ,yuánwèisīlìzhōngxué.
 1	宁波	宁波	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=níngbō|LTranslit=níngbō
@@ -11766,6 +12185,7 @@
 28	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s420
+# parallel_id = zhgsd/test420
 # text = 但在动画版中，由于得到JAXA的协助，得以使用真实姓名。
 # translit = dànzàidònghuàbǎnzhōng,yóuyúdedàoJAXAdexiézhù,deyǐshǐyòngzhēnshíxìngmíng.
 1	但	但	SCONJ	RB	_	15	mark	_	SpaceAfter=No|Translit=dàn|LTranslit=dàn
@@ -11788,6 +12208,7 @@
 18	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s421
+# parallel_id = zhgsd/test421
 # text = 天娱传媒旗下“国民美女”杨洋，经过精心筹备即发行个人首张EP，歌曲颇具文艺气质，配上杨洋干净声线，为华语乐坛又带来了多首独特清新的民谣新作。
 # translit = tiānyúchuánméiqíxià“guómínměinǚ”yángyáng,jīngguòjīngxīn筹bèijífāxínggèrénshǒuzhāngEP,gēqūpōjùwényìqìzhì,pèishàngyángyánggànjìngshēngxiàn,wèihuáyǔlè坛yòudàiláileduōshǒudútèqīngxīndemínyáoxīnzuò.
 1	天娱	天娱	PROPN	NNP	_	6	nmod	_	SpaceAfter=No|Translit=tiānyú|LTranslit=tiānyú
@@ -11839,6 +12260,7 @@
 47	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s422
+# parallel_id = zhgsd/test422
 # text = 他还掌握了雷系查克拉的“状态变化”，可以不借助任何媒介使查克拉刀任意变化。
 # translit = tāháizhǎngwòleléixìchákèlāde“zhuàngtàibiànhuà”,kěyǐbùjièzhùrènhéméijièshǐchákèlādāorènyìbiànhuà.
 1	他	他	PRON	PRP	Person=3	18	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -11866,6 +12288,7 @@
 23	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s423
+# parallel_id = zhgsd/test423
 # text = 唯一的财源为青光石，由附近的邻国以谷物来购买。
 # translit = wéiyīdecáiyuánwèiqīngguāngshí,yóufùjìndelínguóyǐgǔwùláigòumǎi.
 1	唯一	唯一	ADJ	JJ	_	3	amod	_	SpaceAfter=No|Translit=wéiyī|LTranslit=wéiyī
@@ -11886,6 +12309,7 @@
 16	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s424
+# parallel_id = zhgsd/test424
 # text = 观察空中星宿位置的模样，以占卜未来“天道”的学问，来作为学习基础的制度（不过问身份、只要拥有广泛才能的人就能被选上）。
 # translit = guānchákōngzhōngxīngsùwèizhìdemóyàng,yǐzhànbowèilái“tiāndào”dexuéwèn,láizuòwèixuéxíjīchǔdezhìdù(bùguòwènshēnfèn,zhǐyàoyōngyǒuguǎngfàncáinéngderénjiùnéngbèixuǎnshàng).
 1	观察	观察	VERB	VV	_	8	advcl	_	SpaceAfter=No|Translit=guānchá|LTranslit=guānchá
@@ -11930,6 +12354,7 @@
 40	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s425
+# parallel_id = zhgsd/test425
 # text = 他在1990年友好运动会和1991年世界游泳锦标赛上也都夺得了金牌。
 # translit = tāzài1990niányouhǎoyùndònghuìhé1991niánshìjièyóuyǒngjǐnbiāosàishàngyědōuduódelejīnpái.
 1	他	他	PRON	PRP	Person=3	18	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -11955,6 +12380,7 @@
 21	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s426
+# parallel_id = zhgsd/test426
 # text = 他几次搬家和转学，同时寻找他可以充分发挥他才华的地方。
 # translit = tājǐcìbānjiāhézhuǎnxué,tóngshíxúnzhǎotākěyǐchōngfēnfāhuītācáihuádedefāng.
 1	他	他	PRON	PRP	Person=3	9	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -11977,6 +12403,7 @@
 18	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s427
+# parallel_id = zhgsd/test427
 # text = 他的绘画作品已经开始被欧洲的不同私人收藏家收藏。
 # translit = tādehuìhuàzuòpǐnyǐjīngkāishǐbèi'ōuzhōudebùtóngsīrénshōucángjiāshōucáng.
 1	他	他	PRON	PRP	Person=3	4	det	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -11996,6 +12423,7 @@
 15	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s428
+# parallel_id = zhgsd/test428
 # text = 在一些城市中，每层的门窗都会安装铁栅栏，另有一些宅邸的每间房都会安装安全门，为安全部队的抵达争取时间。
 # translit = zàiyīxiēchéngshìzhōng,měicéngdeménchuāngdōuhuì'ānzhuāngtiě栅lán,lìngyǒuyīxiēzhái邸deměijiānfángdōuhuì'ānzhuāng'ānquánmén,wèi'ānquánbùduìdedǐdázhēngqǔshíjiān.
 1	在	在	ADP	IN	_	3	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -12034,6 +12462,7 @@
 34	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s429
+# parallel_id = zhgsd/test429
 # text = 越来越多的轮船也开始提供安全室作为反海盗的手段。
 # translit = yuèláiyuèduōdelúnchuányěkāishǐtígōng'ānquánshìzuòwèifǎnhǎidàodeshǒuduàn.
 1	越来越	越来越	ADV	RB	_	2	advmod	_	SpaceAfter=No|Translit=yuèláiyuè|LTranslit=yuèláiyuè
@@ -12054,6 +12483,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s430
+# parallel_id = zhgsd/test430
 # text = 据阿卡德史诗《埃努玛·埃利什》的记载，安努是安莎尔与吉莎尔之子。
 # translit = jù'ākǎdéshǐshī«'āinǔmǎ·'āilìshén»dejìzài,'ānnǔshì'ānshā'ěryǔjíshā'ěrzhīzi.
 1	据	据	ADP	IN	_	10	case	_	SpaceAfter=No|Translit=jù|LTranslit=jù
@@ -12077,6 +12507,7 @@
 19	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s431
+# parallel_id = zhgsd/test431
 # text = 航空公司成立于1987年并完全由TAAG安哥拉航空拥有。
 # translit = hángkōnggōngsīchénglìyú1987niánbìngwánquányóuTAAG'āngēlāhángkōngyōngyǒu.
 1	航空	航空	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=hángkōng|LTranslit=hángkōng
@@ -12095,6 +12526,7 @@
 14	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s432
+# parallel_id = zhgsd/test432
 # text = 此外，他还创办了北京市伊斯兰教经学院，并曾任中国伊斯兰教经学院与北京市伊斯兰教经学院院长。
 # translit = cǐwài,tāháichuàngbànleběijīngshìyīsīlánjiàojīngxuéyuàn,bìngcéngrènzhōngguóyīsīlánjiàojīngxuéyuànyǔběijīngshìyīsīlánjiàojīngxuéyuànyuànzhǎng.
 1	此外	此外	NOUN	NN	_	16	obl	_	SpaceAfter=No|Translit=cǐwài|LTranslit=cǐwài
@@ -12129,6 +12561,7 @@
 30	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s433
+# parallel_id = zhgsd/test433
 # text = 1989年到1994年，她担任芝加哥大学法学院的教授。
 # translit = 1989niándào1994nián,tādānrènzhījiāgēdàxuéfǎxuéyuàndejiàoshòu.
 1	1989	1989	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1989|LTranslit=1989
@@ -12148,6 +12581,7 @@
 15	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s434
+# parallel_id = zhgsd/test434
 # text = 1941年夏天，安妮姐妹俩因此不得不转入犹太人学校就读，在此期间安妮开始写日记。
 # translit = 1941niánxiàtiān,'ān妮jiemèiliǎyīncǐbùdebùzhuǎnrùyóutàirénxuéxiàojiùdú,zàicǐqījiān'ān妮kāishǐxiěrìjì.
 1	1941	1941	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=1941|LTranslit=1941
@@ -12177,6 +12611,7 @@
 25	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s435
+# parallel_id = zhgsd/test435
 # text = 同年接近年尾时，艾迪特带着安妮与玛戈到居于亚琛的外婆罗莎·霍德兰的家中居住，而奥托则继续留在法兰克福，直至他收到在荷兰阿姆斯特丹开设公司的邀请。
 # translit = tóngniánjiējìnniánwěishí,'àidítèdàizhe'ān妮yǔmǎ戈dàojūyúyà琛dewàipóluōshā·霍délándejiāzhōngjūzhù,'ér'àotuōzéjìxùliúzàifǎlánkèfú,zhízhìtāshōudàozàihélán'āmǔsītèdānkāishègōngsīdeyāoqǐng.
 1	同年	同年	NOUN	NN	_	2	nmod:tmod	_	SpaceAfter=No|Translit=tóngnián|LTranslit=tóngnián
@@ -12224,6 +12659,7 @@
 43	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s436
+# parallel_id = zhgsd/test436
 # text = 洛姬诺娃也是俄罗斯最有名的女保镖之一。
 # translit = luò姬诺wáyěshì'éluōsīzuìyǒumíngdenǚbǎo镖zhīyī.
 1	洛姬诺娃	洛姬诺娃	PROPN	NNP	_	10	nsubj	_	SpaceAfter=No|Translit=luò姬诺wá|LTranslit=luò姬诺wá
@@ -12239,6 +12675,7 @@
 11	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s437
+# parallel_id = zhgsd/test437
 # text = 根据台湾乌克兰籍艺人瑞莎的说法，瑞纱与贝索诺娃在德里乌矜斯学校同时接受韵律体操的训练，住在同一间寝室。
 # translit = gēnjùtáiwānwūkèlánjíyìrénruìshādeshuōfǎ,ruìshāyǔbèisuǒ诺wázàidélǐwū矜sīxuéxiàotóngshíjiēshòu韵lǜtǐcāodexunliàn,zhùzàitóngyījiān寝shì.
 1	根据	根据	ADP	IN	_	8	case	_	SpaceAfter=No|Translit=gēnjù|LTranslit=gēnjù
@@ -12272,6 +12709,7 @@
 29	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s438
+# parallel_id = zhgsd/test438
 # text = 8月25日下午1时，国民党成立大会在湖广会馆召开。
 # translit = 8yuè25rìxiàwǔ1shí,guómíndǎngchénglìdàhuìzàihúguǎnghuìguǎnzhàokāi.
 1	8	8	NUM	CD	NumType=Card	7	nummod	_	SpaceAfter=No|Translit=8|LTranslit=8
@@ -12293,6 +12731,7 @@
 17	。	。	PUNCT	.	_	16	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s439
+# parallel_id = zhgsd/test439
 # text = 在丹麦，一个人的姓名只用首字大写字母表示是个被接受的惯例，正如美国人姓名的中间单词用单词的首字大写字母代替。
 # translit = zàidānmài,yīgèréndexìngmíngzhǐyòngshǒuzìdàxiězìmǔbiǎoshìshìgèbèijiēshòudeguànlì,zhèngrúměiguórénxìngmíngdezhōngjiāndāncíyòngdāncídeshǒuzìdàxiězìmǔdàitì.
 1	在	在	VERB	VV	_	20	acl	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -12334,6 +12773,7 @@
 37	。	。	PUNCT	.	_	23	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s440
+# parallel_id = zhgsd/test440
 # text = 印度安得拉邦分为23个县：
 # translit = yìndù'āndelābāngfēnwèi23gèxiàn:
 1	印度	印度	PROPN	NNP	_	3	nmod	_	SpaceAfter=No|Translit=yìndù|LTranslit=yìndù
@@ -12347,6 +12787,7 @@
 9	：	：	PUNCT	:	_	4	punct	_	SpaceAfter=No|Translit=:|LTranslit=:
 
 # sent_id = test-s441
+# parallel_id = zhgsd/test441
 # text = 考南德出生在巴黎，1930年移居美国，1941年加入美国国籍。
 # translit = kǎonándéchūshēngzàibalí,1930niányíjūměiguó,1941niánjiārùměiguóguójí.
 1	考南德	考南德	PROPN	NNP	_	13	nsubj	_	SpaceAfter=No|Translit=kǎonándé|LTranslit=kǎonándé
@@ -12367,6 +12808,7 @@
 16	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s442
+# parallel_id = zhgsd/test442
 # text = 1764年，马塞纳的父亲去世，母亲改嫁，他被送到亲戚处寄养。
 # translit = 1764nián,mǎsāinàdefùqīnqùshì,mǔqīngǎijià,tābèisòngdàoqīnqichùjìyǎng.
 1	1764	1764	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1764|LTranslit=1764
@@ -12389,6 +12831,7 @@
 18	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s443
+# parallel_id = zhgsd/test443
 # text = 该文化的地理分布范围和界限很难精确确定。
 # translit = gāiwénhuàdedelǐfēnbùfànwéihéjièxiànhěnnánjīngquèquèdìng.
 1	该	该	DET	DT	_	2	det	_	SpaceAfter=No|Translit=gāi|LTranslit=gāi
@@ -12405,6 +12848,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s444
+# parallel_id = zhgsd/test444
 # text = 目前他效力于德甲球队美因茨。
 # translit = mùqiántāxiàolìyúdéjiǎqiúduìměiyīn茨.
 1	目前	目前	NOUN	NN	_	3	nmod:tmod	_	SpaceAfter=No|Translit=mùqián|LTranslit=mùqián
@@ -12417,6 +12861,7 @@
 8	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s445
+# parallel_id = zhgsd/test445
 # text = 手提箱载有的就是他在西班牙内战时间拍摄的3500张底片。
 # translit = shǒutíxiāngzàiyǒudejiùshìtāzàixibānyánèizhànshíjiānpāishède3500zhāngdǐpiàn.
 1	手提	手提	VERB	VV	_	2	compound	_	SpaceAfter=No|Translit=shǒutí|LTranslit=shǒutí
@@ -12437,6 +12882,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s446
+# parallel_id = zhgsd/test446
 # text = 然而再回到伦敦的暗房冲洗时，工作人员的失误毁掉了绝大多数底片，经过一番努力，抢救出了其中的11张。
 # translit = rán'érzàihuídàolún敦de'ànfángchōngxǐshí,gōngzuòrényuándeshīwùhuǐdiàolejuédàduōshùdǐpiàn,jīngguòyīfānnǔlì,qiǎngjiùchūleqízhōngde11zhāng.
 1	然而	然而	SCONJ	RB	_	14	mark	_	SpaceAfter=No|Translit=rán'ér|LTranslit=rán'ér
@@ -12474,6 +12920,7 @@
 33	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s447
+# parallel_id = zhgsd/test447
 # text = 就我所知，他是最不适合担当此职者之一。
 # translit = jiùwǒsuǒzhī,tāshìzuìbùshìhédāndāngcǐzhízhězhīyī.
 1	就	就	ADP	IN	_	4	case	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
@@ -12494,6 +12941,7 @@
 16	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s448
+# parallel_id = zhgsd/test448
 # text = 1960年9月30日，安徽电视台开播，是中国最早建立的省级电视台之一。
 # translit = 1960nián9yuè30rì,'ān徽diànshìtáikāibō,shìzhōngguózuìzǎojiànlìdeshěngjídiànshìtáizhīyī.
 1	1960	1960	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=1960|LTranslit=1960
@@ -12521,6 +12969,7 @@
 23	。	。	PUNCT	.	_	22	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s449
+# parallel_id = zhgsd/test449
 # text = 这是继CCTV电视剧频道、湖南电视台卫星频道之后，中国大陆第三家引进泰国电视剧的电视机构。
 # translit = zhèshìjìCCTVdiànshìjùpíndào,húnándiànshìtáiwèixīngpíndàozhīhòu,zhōngguódàlùdìsānjiāyǐnjìntàiguódiànshìjùdediànshìjīgòu.
 1	这	这	PRON	PRD	_	26	nsubj	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -12552,6 +13001,7 @@
 27	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s450
+# parallel_id = zhgsd/test450
 # text = 当年冬，安徽省高等法院迁回安庆原址办公。
 # translit = dāngniándōng,'ān徽shěnggāoděngfǎyuànqiānhuí'ānqìngyuánzhǐbàngōng.
 1	当年	当年	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=dāngnián|LTranslit=dāngnián
@@ -12568,6 +13018,7 @@
 12	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s451
+# parallel_id = zhgsd/test451
 # text = 1917年，在巴埃萨，他认识了费德里克加西亚洛尔迦，他们建立了伟大的友谊。
 # translit = 1917nián,zàiba'āisà,tārènshilefèidélǐkèjiāxiyàluò'ěr迦,tāmenjiànlìlewěidàdeyouyì.
 1	1917	1917	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1917|LTranslit=1917
@@ -12592,6 +13043,7 @@
 20	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s452
+# parallel_id = zhgsd/test452
 # text = 依据《海巡勤务》所列，安检所内一般勤务可分为几种：值班、安检、守望、监卸、巡逻、备勤。
 # translit = yījù«hǎixúnqínwu»suǒliè,'ānjiǎnsuǒnèiyībānqínwukěfēnwèijǐzhǒng:zhíbān,'ānjiǎn,shǒuwàng,jiānxiè,xúnluó,bèiqín.
 1	依据	依据	ADP	IN	_	7	case	_	SpaceAfter=No|Translit=yījù|LTranslit=yījù
@@ -12627,6 +13079,7 @@
 31	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s453
+# parallel_id = zhgsd/test453
 # text = 进出港的船只均需经过海巡人员的安检，故安检所均配合派员执行此一勤务。
 # translit = jìnchūgǎngdechuánzhǐjūnxūjīngguòhǎixúnrényuánde'ānjiǎn,gù'ānjiǎnsuǒjūnpèihépàiyuánzhíxíngcǐyīqínwu.
 1	进出港	进出港	VERB	VV	_	3	acl:relcl	_	SpaceAfter=No|Translit=jìnchūgǎng|LTranslit=jìnchūgǎng
@@ -12653,6 +13106,7 @@
 22	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s454
+# parallel_id = zhgsd/test454
 # text = 现时该公司市场遍布香港、澳门、中国大陆、台湾、日本、马来西亚、泰国、汶莱、印度等地。
 # translit = xiànshígāigōngsīshìchǎngbiànbùxiānggǎng,'àomén,zhōngguódàlù,táiwān,rìběn,mǎláixiyà,tàiguó,汶莱,yìndùděngde.
 1	现时	现时	NOUN	NN	_	5	nmod:tmod	_	SpaceAfter=No|Translit=xiànshí|LTranslit=xiànshí
@@ -12683,6 +13137,7 @@
 26	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s455
+# parallel_id = zhgsd/test455
 # text = 安班加县（Ambanja District）位于马达加斯加北部，是安齐拉纳纳省的一部分，面积6,328平方公里（2,443平方英哩），2001年人口125,056，人口密度为每平方公里19.8人（每平方英哩2,443.3人）。
 # translit = 'ānbānjiāxiàn(Ambanja District)wèiyúmǎdájiāsījiāběibù,shì'ānqílānànàshěngdeyībùfēn,miànjī6,328píngfānggōnglǐ(2,443píngfāngyīngli),2001niánrénkǒu125,056,rénkǒumìdùwèiměipíngfānggōnglǐ19.8rén(měipíngfāngyīngli2,443.3rén).
 1	安班加	安班加	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit='ānbānjiā|LTranslit='ānbānjiā
@@ -12732,6 +13187,7 @@
 45	。	。	PUNCT	.	_	17	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s456
+# parallel_id = zhgsd/test456
 # text = 现时首席执行官为Stuart Harrison。
 # translit = xiànshíshǒuxízhíxíngguānwèiStuart Harrison.
 1	现时	现时	NOUN	NN	_	6	nmod:tmod	_	SpaceAfter=No|Translit=xiànshí|LTranslit=xiànshí
@@ -12744,6 +13200,7 @@
 8	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s457
+# parallel_id = zhgsd/test457
 # text = Anggun是世界上最成功的亚裔歌手，在法国、美国、巴西、比利时、意大利、新加坡、印尼、马来西亚、芬兰、瑞士、西班牙、俄罗斯、德国、加拿大、荷兰、希腊、菲律宾、汶莱、日本等40多个国家也有着高知名度。
 # translit = Anggunshìshìjièshàngzuìchénggōngdeyà裔gēshǒu,zàifǎguó,měiguó,baxi,bǐlìshí,yìdàlì,xīnjiāpō,yìnní,mǎláixiyà,fēnlán,ruìshì,xibānyá,'éluōsī,déguó,jiānádà,hélán,xī腊,fēilǜbīn,汶莱,rìběnděng40duōgèguójiāyěyǒuzhegāozhīmíngdù.
 1	Anggun	Anggun	X	FW	Foreign=Yes	55	nsubj	_	SpaceAfter=No|Translit=Anggun|LTranslit=Anggun
@@ -12808,6 +13265,7 @@
 60	。	。	PUNCT	.	_	55	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s458
+# parallel_id = zhgsd/test458
 # text = 恒河和雅鲁藏布江河口均流出至安达曼海。
 # translit = hénghéhé雅lǔcángbùjiānghékǒujūnliúchūzhì'āndámànhǎi.
 1	恒河	恒河	PROPN	NNP	_	5	nmod	_	SpaceAfter=No|Translit=hénghé|LTranslit=hénghé
@@ -12823,6 +13281,7 @@
 11	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s459
+# parallel_id = zhgsd/test459
 # text = 他效力于瑞典球会佐加顿斯至2009年6月合约结束。
 # translit = tāxiàolìyúruìdiǎnqiúhuì佐jiādùnsīzhì2009nián6yuèhéyuējiéshù.
 1	他	他	PRON	PRP	Person=3	2	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -12841,6 +13300,7 @@
 14	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s460
+# parallel_id = zhgsd/test460
 # text = 他还曾效力比摩治、奥林比查和马利迪莫，他曾引起了多间球会注意，如士砵亭、纽卡素和多蒙特。
 # translit = tāháicéngxiàolìbǐmózhì,'àolínbǐcháhémǎlìdímò,tācéngyǐnqǐleduōjiānqiúhuìzhùyì,rúshì砵tíng,niǔkǎsùhéduōméngtè.
 1	他	他	PRON	PRP	Person=3	4	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -12871,6 +13331,7 @@
 26	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s461
+# parallel_id = zhgsd/test461
 # text = 此外当局亦会研究兴建垂直运输系统，提供无障碍的便利连接，以及在岩洞提供商业设施，例如餐厅及咖啡厅。
 # translit = cǐwàidāngjúyìhuìyánjiūxìngjiànchuízhíyùnshūxìtǒng,tígōngwúzhàng'àidebiànlìliánjiē,yǐjízàiyándòngtígōngshāngyèshèshī,lìrúcāntīngjíkāfēitīng.
 1	此外	此外	NOUN	NN	_	11	obl	_	SpaceAfter=No|Translit=cǐwài|LTranslit=cǐwài
@@ -12905,6 +13366,7 @@
 30	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s462
+# parallel_id = zhgsd/test462
 # text = 相关基建工程在2015年中完成后，将提供道路连接安达臣道及安达臣道石矿场发展计划用地。
 # translit = xiāngguānjījiàngōngchéngzài2015niánzhōngwánchénghòu,jiāngtígōngdàolùliánjiē'āndáchéndàojí'āndáchéndàoshíkuàngchǎngfāzhǎnjìhuàyòngde.
 1	相关	相关	ADJ	JJ	_	3	amod	_	SpaceAfter=No|Translit=xiāngguān|LTranslit=xiāngguān
@@ -12934,6 +13396,7 @@
 25	。	。	PUNCT	.	_	12	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s463
+# parallel_id = zhgsd/test463
 # text = 而岩壁及石矿公园的设计及工程将会考虑采纳早前在公众参与活动中举行概念设计比赛的参赛作品，由康乐及文化事务署所获得的拨款进行。
 # translit = 'éryánbìjíshíkuànggōngyuándeshèjìjígōngchéngjiānghuìkǎolǜcǎinàzǎoqiánzàigōngzhòngcānyǔhuódòngzhōngjǔxínggàiniànshèjìbǐsàidecānsàizuòpǐn,yóukānglèjíwénhuàshìwushǔsuǒhuòdedebōkuǎnjìnxíng.
 1	而	而	SCONJ	RB	_	38	mark	_	SpaceAfter=No|Translit='ér|LTranslit='ér
@@ -12977,6 +13440,7 @@
 39	。	。	PUNCT	.	_	38	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s464
+# parallel_id = zhgsd/test464
 # text = 冬天的高原更是特别的严峻。
 # translit = dōngtiāndegāoyuángèngshìtèbiédeyánjùn.
 1	冬天	冬天	NOUN	NN	_	3	nmod	_	SpaceAfter=No|Translit=dōngtiān|LTranslit=dōngtiān
@@ -12989,6 +13453,7 @@
 8	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s465
+# parallel_id = zhgsd/test465
 # text = 最热的地区是科尼亚盆地和马拉蒂亚盆地，年降雨量常常少于300毫米。
 # translit = zuìrèdedeqūshìkēníyàpéndehémǎlādìyàpénde,niánjiàngyǔliàngchángchángshǎoyú300háomǐ.
 1	最热	最热	ADJ	JJ	_	3	amod	_	SpaceAfter=No|Translit=zuìrè|LTranslit=zuìrè
@@ -13012,6 +13477,7 @@
 19	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s466
+# parallel_id = zhgsd/test466
 # text = 安阳县是中国河南省安阳市下辖的一个县，位于河南省北缘，安阳市北部。
 # translit = 'ānyángxiànshìzhōngguóhénánshěng'ānyángshìxiàxiádeyīgèxiàn,wèiyúhénánshěngběiyuán,'ānyángshìběibù.
 1	安阳	安阳	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit='ānyáng|LTranslit='ānyáng
@@ -13040,6 +13506,7 @@
 24	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s467
+# parallel_id = zhgsd/test467
 # text = 她其后更与Elite签约。
 # translit = tāqíhòugèngyǔEliteqiānyuē.
 1	她	她	PRON	PRP	Person=3	6	nsubj	_	SpaceAfter=No|Translit=tā|LTranslit=tā
@@ -13051,6 +13518,7 @@
 7	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s468
+# parallel_id = zhgsd/test468
 # text = 塔内每层都有一道宽6尺宽的走廊，游客可到走廊欣赏安顺市的景色。
 # translit = tǎnèiměicéngdōuyǒuyīdàokuān6chǐkuāndezǒu廊,yóukèkědàozǒu廊xīnshǎng'ānshùnshìdejǐngsè.
 1	塔内	塔内	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=tǎnèi|LTranslit=tǎnèi
@@ -13078,6 +13546,7 @@
 23	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s469
+# parallel_id = zhgsd/test469
 # text = 由于宋军人数太少，刘平、石元孙被俘。
 # translit = yóuyú宋jūnrénshùtàishǎo,刘píng,shíyuánsūnbèifú.
 1	由于	由于	ADP	IN	_	5	case	_	SpaceAfter=No|Translit=yóuyú|LTranslit=yóuyú
@@ -13096,6 +13565,7 @@
 14	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s470
+# parallel_id = zhgsd/test470
 # text = 1952年12月美国总统艾森豪威尔访问韩国，他担任检阅主管。
 # translit = 1952nián12yuèměiguózǒngtǒng'àisēnháowēi'ěrfǎngwènhánguó,tādānrènjiǎnyuèzhǔguǎn.
 1	1952	1952	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1952|LTranslit=1952
@@ -13115,6 +13585,7 @@
 15	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s471
+# parallel_id = zhgsd/test471
 # text = 1960年3·15选举舞弊引发群众抗议示威，学生示威扩大为4·19学运，他任戒严司令官，1960年5月辞去陆军参谋长职务，并在美国留学1年，1961年5月在华盛顿DC访问时得知5.16军事政变的消息。
 # translit = 1960nián3·15xuǎnjǔwǔ弊yǐnfāqúnzhòngkàngyìshìwēi,xuéshēngshìwēikuòdàwèi4·19xuéyùn,tārènjièyánsīlìngguān,1960nián5yuècíqùlùjūncānmóuzhǎngzhíwu,bìngzàiměiguóliúxué1nián,1961nián5yuèzàihuáshèngdùnDCfǎngwènshídezhī5.16jūnshìzhèngbiàndexiāoxi.
 1	1960	1960	NUM	CD	NumType=Card	4	nummod	_	SpaceAfter=No|Translit=1960|LTranslit=1960
@@ -13175,6 +13646,7 @@
 56	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s472
+# parallel_id = zhgsd/test472
 # text = 抗战胜利后，兼办《天行报》、《原子能》杂志。
 # translit = kàngzhànshènglìhòu,jiānbàn«tiānxíngbào»,«yuánzinéng»zázhì.
 1	抗战	抗战	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=kàngzhàn|LTranslit=kàngzhàn
@@ -13196,6 +13668,7 @@
 17	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s473
+# parallel_id = zhgsd/test473
 # text = 神学是自觉宗教与自发宗教的最大分别，因为神学有其理论化及系统化，而自发宗教是不具神学体系的。
 # translit = shénxuéshìzìjuézōngjiàoyǔzìfāzōngjiàodezuìdàfēnbié,yīnwèishénxuéyǒuqílǐlùnhuàjíxìtǒnghuà,'érzìfāzōngjiàoshìbùjùshénxuétǐxìde.
 1	神学	神学	NOUN	NN	_	10	nsubj	_	SpaceAfter=No|Translit=shénxué|LTranslit=shénxué
@@ -13231,6 +13704,7 @@
 31	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s474
+# parallel_id = zhgsd/test474
 # text = 这种信仰被视为万物的起源和归宿，一切存在的根基及依据。
 # translit = zhèzhǒngxìnyǎngbèishìwèiwànwùdeqǐyuánhéguīsù,yīqiècúnzàidegēnjījíyījù.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -13254,6 +13728,7 @@
 19	。	。	PUNCT	.	_	5	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s475
+# parallel_id = zhgsd/test475
 # text = 不料明军舰队挺进江面后，以大斧斫断大铁索，逆流而上。
 # translit = bùliàomíngjūnjiànduìtǐngjìnjiāngmiànhòu,yǐdàfǔ斫duàndàtiěsuǒ,逆liú'érshàng.
 1	不料	料	VERB	VV	Polarity=Neg	0	root	_	SpaceAfter=No|Translit=bùliào|LTranslit=liào
@@ -13276,6 +13751,7 @@
 18	。	。	PUNCT	.	_	1	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s476
+# parallel_id = zhgsd/test476
 # text = 英语中定语从句中甚至还可能包含定语从句，即多重定语从句。
 # translit = yīngyǔzhōngdìngyǔcóngjùzhōngshénzhìháikěnéngbāohándìngyǔcóngjù,jíduōzhòngdìngyǔcóngjù.
 1	英	英	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=yīng|LTranslit=yīng
@@ -13299,6 +13775,7 @@
 19	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s477
+# parallel_id = zhgsd/test477
 # text = 就像所有的大卖场一样，宜家家居吸引的消费者来自于范围非常广大的地区。
 # translit = jiùxiàngsuǒyǒudedàmàichǎngyīyàng,yijiājiājūxīyǐndexiāofèizhěláizìyúfànwéifēichángguǎngdàdedeqū.
 1	就	就	SCONJ	RB	_	7	mark	_	SpaceAfter=No|Translit=jiù|LTranslit=jiù
@@ -13326,6 +13803,7 @@
 23	。	。	PUNCT	.	_	15	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s478
+# parallel_id = zhgsd/test478
 # text = 这样的结果是可以生产出具有高度适应力的家具，无论是大型房屋还是为数越来越众多却受到忽略的小型寓所，这些家具都能够改变大小来容纳。
 # translit = zhèyàngdejiéguǒshìkěyǐshēngchǎnchūjùyǒugāodùshìyīnglìdejiājù,wúlùnshìdàxíngfángwūháishìwèishùyuèláiyuèzhòngduōquèshòudàohū'èdexiǎoxíngyùsuǒ,zhèxiējiājùdōunénggòugǎibiàndàxiǎoláiróngnà.
 1	这样	这样	PRON	PRD	_	3	det	_	SpaceAfter=No|Translit=zhèyàng|LTranslit=zhèyàng
@@ -13368,6 +13846,7 @@
 38	。	。	PUNCT	.	_	4	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s479
+# parallel_id = zhgsd/test479
 # text = 宜都市是地处中华人民共和国湖北省西南部的一个县级市，隶属地级宜昌市管辖，位于长江南岸，长江与其支流清江交汇处。
 # translit = yidōushìshìdechùzhōnghuárénmíngònghéguóhúběishěngxinánbùdeyīgèxiànjíshì,lìshǔdejíyi昌shìguǎnxiá,wèiyúzhǎngjiāngnán'àn,zhǎngjiāngyǔqízhīliúqīngjiāngjiāohuìchù.
 1	宜都	宜都	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=yidōu|LTranslit=yidōu
@@ -13410,6 +13889,7 @@
 38	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s480
+# parallel_id = zhgsd/test480
 # text = 宜都市处于鄂西山地和江汉平原过渡地带，地势西南高、东北低，由西南向东北倾斜，是一个丘陵起伏的半山区。
 # translit = yidōushìchùyú鄂xishāndehéjiānghànpíngyuánguòdùdedài,deshìxinángāo,dōngběidī,yóuxinánxiàngdōngběiqīngxié,shìyīgèqiūlíngqǐfúdebànshānqū.
 1	宜都	宜都	PROPN	NNP	_	2	compound	_	SpaceAfter=No|Translit=yidōu|LTranslit=yidōu
@@ -13449,6 +13929,7 @@
 35	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s481
+# parallel_id = zhgsd/test481
 # text = 2012年3月15日，徐明遭到了中纪委调查，大连实德集团表示徐明已失去联络半个月。
 # translit = 2012nián3yuè15rì,xúmíngzāodàolezhōngjìwěidiàochá,dàliánshídéjítuánbiǎoshìxúmíngyǐshīqùliánluòbàngèyuè.
 1	2012	2012	NUM	CD	NumType=Card	6	nummod	_	SpaceAfter=No|Translit=2012|LTranslit=2012
@@ -13480,6 +13961,7 @@
 27	。	。	PUNCT	.	_	10	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s482
+# parallel_id = zhgsd/test482
 # text = 实德集团是大连市的一家民营企业，成立于1992年。
 # translit = shídéjítuánshìdàliánshìdeyījiāmínyíngqǐyè,chénglìyú1992nián.
 1	实德	实德	PROPN	NNP	_	2	nmod	_	SpaceAfter=No|Translit=shídé|LTranslit=shídé
@@ -13501,6 +13983,7 @@
 17	。	。	PUNCT	.	_	13	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s483
+# parallel_id = zhgsd/test483
 # text = 总部位于大连市西岗区高尔基路38号。
 # translit = zǒngbùwèiyúdàliánshìxigǎngqūgāo'ěrjīlù38hào.
 1	总部	总部	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=zǒngbù|LTranslit=zǒngbù
@@ -13517,6 +14000,7 @@
 12	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s484
+# parallel_id = zhgsd/test484
 # text = 在戏剧上，审美距离指观众不应混淆舞台表演与现实世界的距离。
 # translit = zàixìjùshàng,shěnměijùlízhǐguānzhòngbùyīnghùn淆wǔtáibiǎoyǎnyǔxiànshíshìjièdejùlí.
 1	在	在	ADP	IN	_	2	case	_	SpaceAfter=No|Translit=zài|LTranslit=zài
@@ -13539,6 +14023,7 @@
 18	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s485
+# parallel_id = zhgsd/test485
 # text = 审美距离的存在并不排除观众方面出现某种“对号入座”的现象。
 # translit = shěnměijùlídecúnzàibìngbùpáichúguānzhòngfāngmiànchūxiànmǒuzhǒng“duìhàorùzuò”dexiànxiàng.
 1	审美	审美	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=shěnměi|LTranslit=shěnměi
@@ -13561,6 +14046,7 @@
 18	。	。	PUNCT	.	_	7	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s486
+# parallel_id = zhgsd/test486
 # text = 主要职责是管理宫廷的修缮、食事、扫除、医疗等事庶务，以及天皇财产的管理。
 # translit = zhǔyàozhízéshìguǎnlǐgōngtíngdexiū缮,shíshì,sǎochú,yīliáoděngshì庶wu,yǐjítiānhuángcáichǎndeguǎnlǐ.
 1	主要	主要	ADJ	JJ	_	2	amod	_	SpaceAfter=No|Translit=zhǔyào|LTranslit=zhǔyào
@@ -13588,6 +14074,7 @@
 23	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s487
+# parallel_id = zhgsd/test487
 # text = 10日上午在陆军省的会议中，青年军官们要求阿南惟几辞职，从而逼迫内阁总辞职，以达到阻止无条件投降的目的。
 # translit = 10rìshàngwǔzàilùjūnshěngdehuìyìzhōng,qīngniánjūnguānmenyàoqiú'ānánwéijǐcízhí,cóng'érbīpònèi阁zǒngcízhí,yǐdádàozǔzhǐwútiáojiàntóujiàngdemùde.
 1	10	10	NUM	CD	NumType=Card	3	nummod	_	SpaceAfter=No|Translit=10|LTranslit=10
@@ -13625,6 +14112,7 @@
 33	。	。	PUNCT	.	_	26	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s488
+# parallel_id = zhgsd/test488
 # text = 另一方面，畑中等人也试图做近卫师团的工作。
 # translit = lìngyīfāngmiàn,畑zhōngděngrényěshìtúzuòjìnwèishītuándegōngzuò.
 1	另	另	DET	DT	_	3	det	_	SpaceAfter=No|Translit=lìng|LTranslit=lìng
@@ -13644,6 +14132,7 @@
 15	。	。	PUNCT	.	_	9	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s489
+# parallel_id = zhgsd/test489
 # text = 天皇随即表示赞同外相东乡的主张，会议遂做出了接受波茨坦宣言的决定。
 # translit = tiānhuángsuíjíbiǎoshìzàntóngwàixiāngdōngxiāngdezhǔzhāng,huìyì遂zuòchūlejiēshòubō茨tǎnxuānyándejuédìng.
 1	天皇	天皇	NOUN	NN	_	3	nsubj	_	SpaceAfter=No|Translit=tiānhuáng|LTranslit=tiānhuáng
@@ -13667,6 +14156,7 @@
 19	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s490
+# parallel_id = zhgsd/test490
 # text = 宫城因为自负的性格，曾经与三井寿有过一段私人恩怨。
 # translit = gōngchéngyīnwèizìfùdexìnggé,céngjīngyǔsānjǐngshòuyǒuguòyīduànsīrén'ēnyuàn.
 1	宫城	宫城	PROPN	NNP	_	11	nsubj	_	SpaceAfter=No|Translit=gōngchéng|LTranslit=gōngchéng
@@ -13688,6 +14178,7 @@
 17	。	。	PUNCT	.	_	11	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s491
+# parallel_id = zhgsd/test491
 # text = 1912年，宫崎滔天参加了孙文就任临时大总统的仪式。
 # translit = 1912nián,gōngqítāotiāncānjiālesūnwénjiùrènlínshídàzǒngtǒngdeyíshì.
 1	1912	1912	NUM	CD	NumType=Card	2	nummod	_	SpaceAfter=No|Translit=1912|LTranslit=1912
@@ -13708,6 +14199,7 @@
 16	。	。	PUNCT	.	_	6	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s492
+# parallel_id = zhgsd/test492
 # text = 吉本本想召集沼田一家进行家访，然而关键人物茂之却不肯露面，面对如此学生，吉本作出了惊人之举。
 # translit = jíběnběnxiǎngzhàojí沼tiányījiājìnxíngjiāfǎng,rán'érguānjiànrénwùmàozhīquèbùkěnlùmiàn,miànduìrúcǐxuéshēng,jíběnzuòchūlejīngrénzhījǔ.
 1	吉本	吉本	PROPN	NNP	_	8	nsubj	_	SpaceAfter=No|Translit=jíběn|LTranslit=jíběn
@@ -13741,6 +14233,7 @@
 29	。	。	PUNCT	.	_	8	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s493
+# parallel_id = zhgsd/test493
 # text = 安仁屋政昭以长达20多年对当地居民的采访经验为依据，其证言表明无论是屠杀居民还是集体自杀的责任都在日本军方，对于居民的牺牲，军方总指挥官曾有过计划（命令），另外即使没有命令，各级官兵都自发作出了上述行为。
 # translit = 'ānrénwūzhèng昭yǐzhǎngdá20duōniánduìdāngdejūmíndecǎifǎngjīngyànwèiyījù,qízhèngyánbiǎomíngwúlùnshìtúshājūmínháishìjítǐzìshādezérèndōuzàirìběnjūnfāng,duìyújūmíndexīshēng,jūnfāngzǒngzhǐhuīguāncéngyǒuguòjìhuà(mìnglìng),lìngwàijíshǐméiyǒumìnglìng,gèjíguānbīngdōuzìfāzuòchūleshàngshùxíngwèi.
 1	安仁屋	安仁屋	PROPN	NNP	_	3	nsubj	_	SpaceAfter=No|Translit='ānrénwū|LTranslit='ānrénwū
@@ -13808,6 +14301,7 @@
 63	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s494
+# parallel_id = zhgsd/test494
 # text = 家用伺服器通常都会扮演网路储存设备的角色，为所有使用者提供安全的档案储存服务，而且拥有存取控制管理。
 # translit = jiāyòngcìfúqìtōngchángdōuhuìbanyǎnwǎnglùchǔcúnshèbèidejiǎosè,wèisuǒyǒushǐyòngzhětígōng'ānquándedàng'ànchǔcúnfúwu,'érqiěyōngyǒucúnqǔkòngzhìguǎnlǐ.
 1	家	家	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=jiā|LTranslit=jiā
@@ -13843,6 +14337,7 @@
 31	。	。	PUNCT	.	_	27	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s495
+# parallel_id = zhgsd/test495
 # text = 酪梨糖是利用高科技分子蒸馏法由天然酪梨中萃取。
 # translit = 酪lítángshìlìyònggāokējìfēnzizhēng馏fǎyóutiānrán酪lízhōng萃qǔ.
 1	酪梨	酪梨	NOUN	NN	_	2	compound	_	SpaceAfter=No|Translit=酪lí|LTranslit=酪lí
@@ -13862,6 +14357,7 @@
 15	。	。	PUNCT	.	_	3	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s496
+# parallel_id = zhgsd/test496
 # text = 宽吻海豚可以同其他种类的海豚交配，在自然界和圈养状态下都有这种情况发生。
 # translit = kuānwěnhǎi豚kěyǐtóngqítāzhǒnglèidehǎi豚jiāopèi,zàizìránjièhéquānyǎngzhuàngtàixiàdōuyǒuzhèzhǒngqíngkuàngfāshēng.
 1	宽吻海豚	宽吻海豚	NOUN	NN	_	8	nsubj	_	SpaceAfter=No|Translit=kuānwěnhǎi豚|LTranslit=kuānwěnhǎi豚
@@ -13889,6 +14385,7 @@
 23	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s497
+# parallel_id = zhgsd/test497
 # text = 宵禁就是管理员下班（0:00 AM）到次日上班之前（9:00 AM）禁止发帖和回复，该规则在2010上海世博会期间实行，导致大量海外网友由于时差缘故无法正常发帖。
 # translit = xiāojìnjiùshìguǎnlǐyuánxiàbān(0:00 AM)dàocìrìshàngbānzhīqián(9:00 AM)jìnzhǐfā帖héhuífù,gāiguīzézài2010shànghǎishìbóhuìqījiānshíxíng,dǎozhìdàliànghǎiwàiwǎngyouyóuyúshíchàyuángùwúfǎzhèngchángfā帖.
 1	宵禁	宵禁	NOUN	NN	_	2	nsubj	_	SpaceAfter=No|Translit=xiāojìn|LTranslit=xiāojìn
@@ -13936,6 +14433,7 @@
 43	。	。	PUNCT	.	_	2	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s498
+# parallel_id = zhgsd/test498
 # text = 分布于西达印度洋塞席尔群岛及马尔地夫群岛以及海南省中沙群岛等，属于热带浅海底层鱼。
 # translit = fēnbùyúxidáyìndùyángsāixí'ěrqúndǎojímǎ'ěrdefuqúndǎoyǐjíhǎinánshěngzhōngshāqúndǎoděng,shǔyúrèdàiqiǎnhǎidǐcéngyú.
 1	分布	分布	VERB	VV	_	18	advcl	_	SpaceAfter=No|Translit=fēnbù|LTranslit=fēnbù
@@ -13965,6 +14463,7 @@
 25	。	。	PUNCT	.	_	18	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s499
+# parallel_id = zhgsd/test499
 # text = 这两句话的意思分别和前述两句话意义相同。
 # translit = zhèliǎngjùhuàdeyìsīfēnbiéhéqiánshùliǎngjùhuàyìyìxiāngtóng.
 1	这	这	DET	DT	_	3	det	_	SpaceAfter=No|Translit=zhè|LTranslit=zhè
@@ -13984,6 +14483,7 @@
 15	。	。	PUNCT	.	_	14	punct	_	SpaceAfter=No|Translit=.|LTranslit=.
 
 # sent_id = test-s500
+# parallel_id = zhgsd/test500
 # text = 密室推理（Locked room mystery，或称密室杀人）是推理小说常见的一种类型。
 # translit = mìshìtuīlǐ(Locked room mystery,huòchēngmìshìshārén)shìtuīlǐxiǎoshuōchángjiàndeyīzhǒnglèixíng.
 1	密室	密室	NOUN	NN	_	2	nmod	_	SpaceAfter=No|Translit=mìshì|LTranslit=mìshì


### PR DESCRIPTION
- update README metadata and add parallel IDs
     - add "Parallel: "zhgsd" to indicate parallel data availability
- add " parallel_id = zhgsd/{dev{n}, test{n}, train{n}}/part{n} alt{n}" format to support automated parallel sentences identification, where n = any number (positive intergers, arabic numerals, starts with 1)